### PR TITLE
Add GoVersion to ServerInfo struct for parity with gnatsd

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -209,6 +209,7 @@ type serverInfo struct {
 	Host         string `json:"host"`
 	Port         uint   `json:"port"`
 	Version      string `json:"version"`
+	GoVersion    string `json:"go"`
 	AuthRequired bool   `json:"auth_required"`
 	SslRequired  bool   `json:"ssl_required"`
 	MaxPayload   int64  `json:"max_payload"`


### PR DESCRIPTION
Added because I noticed it was missing. It is defined in gnatsd but not here.

https://github.com/nats-io/gnatsd/blob/master/server/server.go

Let me know if I missed anything, new to the project.

Tests are all passing for me locally.

@derekcollison @wallyqs 