### PR TITLE
Enforce MaxPayload on the client

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -279,7 +279,7 @@ func TestErrOnConnectAndDeadlock(t *testing.T) {
 func TestErrOnMaxPayloadLimit(t *testing.T) {
 	serverInfo := "INFO {\"server_id\":\"foobar\",\"version\":\"0.6.6\",\"go\":\"go1.4.2\",\"host\":\"%s\",\"port\":%d,\"auth_required\":false,\"ssl_required\":false,\"max_payload\":10}\r\n"
 
-	l, e := net.Listen("tcp", "127.0.0.1:4222")
+	l, e := net.Listen("tcp", "127.0.0.1:0")
 	if e != nil {
 		t.Fatal("Could not listen on an ephemeral port")
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -297,8 +297,13 @@ func TestErrOnMaxPayloadLimit(t *testing.T) {
 		defer conn.Close()
 		info := fmt.Sprintf(serverInfo, addr.IP, addr.Port)
 		conn.Write([]byte(info))
-		// Wait a bit for client to connect and make a ping
-		time.Sleep(100 * time.Millisecond)
+
+		// Read connect and ping commands sent from the client
+		line := make([]byte, 111)
+		_, err := conn.Read(line)
+		if err != nil {
+			t.Fatal("Expected CONNECT and PING from client, got: %s", err)
+		}
 		conn.Write([]byte("PONG\r\n"))
 	}()
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -286,59 +286,43 @@ func TestErrOnMaxPayloadLimit(t *testing.T) {
 	tl := l.(*net.TCPListener)
 	addr := tl.Addr().(*net.TCPAddr)
 
-	// Used to synchronize
-	ch := make(chan struct{})
-
-	// Simple server which send back an INFO message
-	// with custom max payload size.
+	// Send back an INFO message with custom max payload size on connect.
+	var conn net.Conn
+	var err error
 	go func() {
-		for {
-			select {
-			case <-time.After(5 * time.Second):
-				break
-			default:
-				conn, err := l.Accept()
-				if err != nil {
-					t.Fatalf("Error accepting client connection: %v\n", err)
-				}
-				info := fmt.Sprintf(serverInfo, addr.IP, addr.Port)
-				conn.Write([]byte(info))
-				conn.Write([]byte("PONG\r\n"))
-				time.Sleep(500 * time.Millisecond)
-				conn.Close()
-			}
+		conn, err = l.Accept()
+		if err != nil {
+			fmt.Printf("Error accepting client connection: %v\n", err)
 		}
+		defer conn.Close()
+		info := fmt.Sprintf(serverInfo, addr.IP, addr.Port)
+		conn.Write([]byte(info))
+		// Wait a bit for client to connect and make a ping
+		time.Sleep(100 * time.Millisecond)
+		conn.Write([]byte("PONG\r\n"))
 	}()
 
-	var nc *Conn
-	var err error
+	doneCh := make(chan struct{})
 	go func() {
 		natsUrl := fmt.Sprintf("nats://%s:%d", addr.IP, addr.Port)
 		opts := DefaultOptions
 		opts.Servers = []string{natsUrl}
-		opts.EnforceMaxPayload = true
-
-		for i := 0; i < 10; i++ {
-			nc, err = opts.Connect()
-			if err == nil {
-				break
-			}
-			time.Sleep(200 * time.Millisecond)
-		}
+		nc, err := opts.Connect()
 		if err != nil {
 			t.Fatalf("Expected INFO message with custom max payload, got: %s", err)
 		}
-		ch <- struct{}{}
-	}()
 
-	// Setup a timer to watch for deadlock
-	select {
-	case <-ch:
-		err := nc.Publish("hello", []byte("hello world"))
+		err = nc.Publish("hello", []byte("hello world"))
 		if err != ErrMaxPayload {
 			t.Fatalf("Expected to fail trying to send more than max payload, got: %s", err)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatalf("Connect took too long")
+		doneCh <- struct{}{}
+	}()
+
+	select {
+	case <-doneCh:
+		break
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Timeout.")
 	}
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -303,7 +303,7 @@ func TestErrOnMaxPayloadLimit(t *testing.T) {
 		line := make([]byte, 111)
 		_, err := conn.Read(line)
 		if err != nil {
-			t.Fatal("Expected CONNECT and PING from client, got: %s", err)
+			t.Fatalf("Expected CONNECT and PING from client, got: %s", err)
 		}
 		conn.Write([]byte("PONG\r\n"))
 	}()

--- a/conn_test.go
+++ b/conn_test.go
@@ -320,7 +320,7 @@ func TestErrOnMaxPayloadLimit(t *testing.T) {
 
 		got := nc.MaxPayload()
 		if got != expectedMaxPayload {
-			t.Fatal("Expected MaxPayload to be %d, got: %d", expectedMaxPayload, got)
+			t.Fatalf("Expected MaxPayload to be %d, got: %d", expectedMaxPayload, got)
 		}
 
 		err = nc.Publish("hello", []byte("hello world"))

--- a/nats.go
+++ b/nats.go
@@ -1154,7 +1154,9 @@ func (nc *Conn) publish(subj, reply string, data []byte) error {
 	nc.mu.Lock()
 
 	// Proactively reject payloads over the threshold set by server.
-	if len(data) > int(nc.info.MaxPayload) {
+	var msgSize int64
+	msgSize = int64(len(data))
+	if msgSize > nc.info.MaxPayload {
 		nc.err = ErrMaxPayload
 		err := nc.err
 		nc.mu.Unlock()

--- a/nats.go
+++ b/nats.go
@@ -1689,6 +1689,5 @@ func (nc *Conn) Stats() Statistics {
 func (nc *Conn) MaxPayload() int64 {
 	nc.mu.Lock()
 	defer nc.mu.Unlock()
-	max := nc.info.MaxPayload
-	return max
+	return nc.info.MaxPayload
 }

--- a/nats.go
+++ b/nats.go
@@ -112,8 +112,7 @@ type Options struct {
 	SubChanLen int
 
 	// Avoid publishing message if size above this threshold
-	MaxPayload        int
-	EnforceMaxPayload bool
+	MaxPayload int
 }
 
 const (
@@ -1160,7 +1159,7 @@ func (nc *Conn) publish(subj, reply string, data []byte) error {
 
 	// Proactively reject payloads over the threshold set by server,
 	// only if explicitly enabled when customizing the connection.
-	if nc.Opts.EnforceMaxPayload && len(data) > nc.Opts.MaxPayload {
+	if len(data) > nc.Opts.MaxPayload {
 		nc.err = ErrMaxPayload
 		err := nc.err
 		nc.mu.Unlock()

--- a/nats.go
+++ b/nats.go
@@ -1118,7 +1118,6 @@ func (nc *Conn) processInfo(info string) {
 		return
 	}
 	nc.err = json.Unmarshal([]byte(info), &nc.info)
-	nc.Opts.MaxPayload = int(nc.info.MaxPayload)
 }
 
 // LastError reports the last error encountered via the Connection.
@@ -1159,7 +1158,7 @@ func (nc *Conn) publish(subj, reply string, data []byte) error {
 
 	// Proactively reject payloads over the threshold set by server,
 	// only if explicitly enabled when customizing the connection.
-	if len(data) > nc.Opts.MaxPayload {
+	if len(data) > nc.MaxPayload() {
 		nc.err = ErrMaxPayload
 		err := nc.err
 		nc.mu.Unlock()
@@ -1686,4 +1685,9 @@ func (nc *Conn) Stats() Statistics {
 	defer nc.mu.Unlock()
 	stats := nc.Statistics
 	return stats
+}
+
+// MaxPayload returns the size limit that a message payload can have.
+func (nc *Conn) MaxPayload() int {
+	return int(nc.info.MaxPayload)
 }

--- a/nats.go
+++ b/nats.go
@@ -1154,7 +1154,7 @@ func (nc *Conn) publish(subj, reply string, data []byte) error {
 	nc.mu.Lock()
 
 	// Proactively reject payloads over the threshold set by server.
-	if len(data) > nc.MaxPayload() {
+	if len(data) > int(nc.info.MaxPayload) {
 		nc.err = ErrMaxPayload
 		err := nc.err
 		nc.mu.Unlock()
@@ -1684,6 +1684,9 @@ func (nc *Conn) Stats() Statistics {
 }
 
 // MaxPayload returns the size limit that a message payload can have.
-func (nc *Conn) MaxPayload() int {
-	return int(nc.info.MaxPayload)
+func (nc *Conn) MaxPayload() int64 {
+	nc.mu.Lock()
+	defer nc.mu.Unlock()
+	max := nc.info.MaxPayload
+	return max
 }

--- a/nats.go
+++ b/nats.go
@@ -1153,8 +1153,7 @@ const digits = "0123456789"
 func (nc *Conn) publish(subj, reply string, data []byte) error {
 	nc.mu.Lock()
 
-	// Proactively reject payloads over the threshold set by server,
-	// only if explicitly enabled when customizing the connection.
+	// Proactively reject payloads over the threshold set by server.
 	if len(data) > nc.MaxPayload() {
 		nc.err = ErrMaxPayload
 		err := nc.err

--- a/nats.go
+++ b/nats.go
@@ -110,9 +110,6 @@ type Options struct {
 	// The size of the buffered channel used between the socket
 	// Go routine and the message delivery or sync subscription.
 	SubChanLen int
-
-	// Avoid publishing message if size above this threshold
-	MaxPayload int
 }
 
 const (


### PR DESCRIPTION
Makes the client proactively follow the `MaxPayload` size which was announced by the server upon connect. After this change, the client would get an `ErrMaxPayload` error when trying to publish a message which is larger than this limit.
