### PR TITLE
Atomically load delivered messages accounted value before on compare.

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -982,9 +982,10 @@ func (nc *Conn) deliverMsgs(ch chan *Msg) {
 		if conn == nil || mcb == nil {
 			continue
 		}
-		// FIXME: race on compare?
+
 		atomic.AddUint64(&s.delivered, 1)
-		if max <= 0 || s.delivered <= max {
+		delivered := atomic.LoadUint64(&s.delivered)
+		if max <= 0 || delivered <= max {
 			mcb(m)
 		}
 	}


### PR DESCRIPTION
In order to improve chances that there is not a race in this step.

/cc @derekcollison @kozlovic 

```
WARNING: DATA RACE
Read by goroutine 228:
  github.com/nats-io/nats.TestServerAutoUnsub()
     .../src/github.com/nats-io/nats/sub_test.go:28 +0x3cc
  testing.tRunner()
      .../src/go/src/testing/testing.go:447 +0x133

Previous write by goroutine 256:
  github.com/nats-io/nats.func·077()
      .../src/github.com/nats-io/nats/sub_test.go:17 +0x50
  github.com/nats-io/nats.(*Conn).deliverMsgs()
      .../src/github.com/nats-io/nats/nats.go:988 +0x214

Goroutine 228 (running) created at:
  testing.RunTests()
      .../src/go/src/testing/testing.go:555 +0xd4e
  testing.(*M).Run()
      .../src/go/src/testing/testing.go:485 +0xe0
  main.main()
      github.com/nats-io/nats/_test/_testmain.go:266 +0x28c

Goroutine 256 (running) created at:
  github.com/nats-io/nats.(*Conn).subscribe()
      .../src/github.com/nats-io/nats/nats.go:1294 +0x365
  github.com/nats-io/nats.(*Conn).Subscribe()
      .../src/github.com/nats-io/nats/nats.go:1314 +0xa9
  github.com/nats-io/nats.TestServerAutoUnsub()
      .../src/github.com/nats-io/nats/sub_test.go:18 +0x13f
  testing.tRunner()
      .../src/go/src/testing/testing.go:447 +0x133
```