### PR TITLE
Added benchmarks for encoding, structs only.

### DIFF
--- a/encoders/builtin/gob_test.go
+++ b/encoders/builtin/gob_test.go
@@ -81,7 +81,6 @@ func TestGobMarshalStruct(t *testing.T) {
 	me.Assets["car"] = 100
 
 	ec.Subscribe("gob_struct", func(p *person) {
-		ch <- true
 		if !reflect.DeepEqual(p, me) {
 			t.Fatalf("Did not receive the correct struct response")
 		}
@@ -109,7 +108,6 @@ func BenchmarkGobMarshalStruct(b *testing.B) {
         me.Children["meg"] = &person{Name: "meg", Age: 17, Address: "140 New Montgomery St"}
 
         ec.Subscribe("gob_struct", func(p *person) {
-                ch <- true
                 if !reflect.DeepEqual(p, me) {
                         b.Fatalf("Did not receive the correct struct response")
                 }

--- a/encoders/builtin/gob_test.go
+++ b/encoders/builtin/gob_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/nats-io/nats/test"
 )
 
-func NewGobEncodedConn(t *testing.T) *nats.EncodedConn {
-	ec, err := nats.NewEncodedConn(test.NewDefaultConnection(t), nats.GOB_ENCODER)
+func NewGobEncodedConn(tl test.TestLogger) *nats.EncodedConn {
+        ec, err := nats.NewEncodedConn(test.NewDefaultConnection(tl), nats.GOB_ENCODER)
 	if err != nil {
-		t.Fatalf("Failed to create an encoded connection: %v\n", err)
+                tl.Fatalf("Failed to create an encoded connection: %v\n", err)
 	}
 	return ec
 }
@@ -92,4 +92,34 @@ func TestGobMarshalStruct(t *testing.T) {
 	if e := test.Wait(ch); e != nil {
 		t.Fatal("Did not receive the message")
 	}
+}
+
+func BenchmarkGobMarshalStruct(b *testing.B) {
+        s := test.RunDefaultServer()
+        defer s.Shutdown()
+
+        ec := NewGobEncodedConn(b)
+        defer ec.Close()
+        ch := make(chan bool)
+
+        me := &person{Name: "derek", Age: 22, Address: "140 New Montgomery St"}
+        me.Children = make(map[string]*person)
+
+        me.Children["sam"] = &person{Name: "sam", Age: 19, Address: "140 New Montgomery St"}
+        me.Children["meg"] = &person{Name: "meg", Age: 17, Address: "140 New Montgomery St"}
+
+        ec.Subscribe("gob_struct", func(p *person) {
+                ch <- true
+                if !reflect.DeepEqual(p, me) {
+                        b.Fatalf("Did not receive the correct struct response")
+                }
+                ch <- true
+        })
+
+        for n := 0; n < b.N; n++ {
+                ec.Publish("gob_struct", me)
+                if e := test.Wait(ch); e != nil {
+                        b.Fatal("Did not receive the message")
+                }
+        }
 }

--- a/encoders/builtin/gob_test.go
+++ b/encoders/builtin/gob_test.go
@@ -90,10 +90,13 @@ func TestGobMarshalStruct(t *testing.T) {
 	ec.Publish("gob_struct", me)
 	if e := test.Wait(ch); e != nil {
 		t.Fatal("Did not receive the message")
-	}
+        }
 }
 
-func BenchmarkGobMarshalStruct(b *testing.B) {
+func BenchmarkPublishGobStruct(b *testing.B) {
+        // stop benchmark for set-up
+        b.StopTimer()
+
         s := test.RunDefaultServer()
         defer s.Shutdown()
 
@@ -113,6 +116,9 @@ func BenchmarkGobMarshalStruct(b *testing.B) {
                 }
                 ch <- true
         })
+
+        // resume benchmark
+        b.StartTimer()
 
         for n := 0; n < b.N; n++ {
                 ec.Publish("gob_struct", me)

--- a/encoders/builtin/json_test.go
+++ b/encoders/builtin/json_test.go
@@ -91,7 +91,6 @@ func TestJsonMarshalStruct(t *testing.T) {
 	me.Assets["car"] = 100
 
 	ec.Subscribe("json_struct", func(p *person) {
-		ch <- true
 		if !reflect.DeepEqual(p, me) {
 			t.Fatalf("Did not receive the correct struct response")
 		}
@@ -119,7 +118,6 @@ func BenchmarkJsonMarshalStruct(b *testing.B) {
         me.Children["meg"] = &person{Name: "meg", Age: 17, Address: "140 New Montgomery St"}
 
         ec.Subscribe("json_struct", func(p *person) {
-                ch <- true
                 if !reflect.DeepEqual(p, me) {
                         b.Fatalf("Did not receive the correct struct response")
                 }

--- a/encoders/builtin/json_test.go
+++ b/encoders/builtin/json_test.go
@@ -100,10 +100,13 @@ func TestJsonMarshalStruct(t *testing.T) {
 	ec.Publish("json_struct", me)
 	if e := test.Wait(ch); e != nil {
 		t.Fatal("Did not receive the message")
-	}
+        }
 }
 
-func BenchmarkJsonMarshalStruct(b *testing.B) {
+func BenchmarkPublishJsonStruct(b *testing.B) {
+        // stop benchmark for set-up
+        b.StopTimer()
+
         s := test.RunDefaultServer()
         defer s.Shutdown()
 
@@ -123,6 +126,9 @@ func BenchmarkJsonMarshalStruct(b *testing.B) {
                 }
                 ch <- true
         })
+
+        // resume benchmark
+        b.StartTimer()
 
         for n := 0; n < b.N; n++ {
                 ec.Publish("json_struct", me)

--- a/encoders/builtin/json_test.go
+++ b/encoders/builtin/json_test.go
@@ -111,8 +111,10 @@ func BenchmarkJsonMarshalStruct(b *testing.B) {
         me.Children["meg"] = &person{Name: "meg", Age: 17, Address: "140 New Montgomery St"}
 
         encoder := &builtin.JsonEncoder{}
-        if _, err := encoder.Encode("protobuf_test", me); err != nil {
-                b.Fatalf("Couldn't serialize object", err)
+        for n := 0; n < b.N; n++ {
+                if _, err := encoder.Encode("protobuf_test", me); err != nil {
+                        b.Fatalf("Couldn't serialize object", err)
+                }
         }
 }
 

--- a/encoders/builtin/json_test.go
+++ b/encoders/builtin/json_test.go
@@ -103,6 +103,19 @@ func TestJsonMarshalStruct(t *testing.T) {
         }
 }
 
+func BenchmarkJsonMarshalStruct(b *testing.B) {
+        me := &person{Name: "derek", Age: 22, Address: "140 New Montgomery St"}
+        me.Children = make(map[string]*person)
+
+        me.Children["sam"] = &person{Name: "sam", Age: 19, Address: "140 New Montgomery St"}
+        me.Children["meg"] = &person{Name: "meg", Age: 17, Address: "140 New Montgomery St"}
+
+        encoder := &builtin.JsonEncoder{}
+        if _, err := encoder.Encode("protobuf_test", me); err != nil {
+                b.Fatalf("Couldn't serialize object", err)
+        }
+}
+
 func BenchmarkPublishJsonStruct(b *testing.B) {
         // stop benchmark for set-up
         b.StopTimer()

--- a/encoders/protobuf/protobuf_test.go
+++ b/encoders/protobuf/protobuf_test.go
@@ -44,10 +44,13 @@ func TestProtoMarshalStruct(t *testing.T) {
 	ec.Publish("protobuf_test", me)
 	if e := test.Wait(ch); e != nil {
 		t.Fatal("Did not receive the message")
-	}
+        }
 }
 
-func BenchmarkProtobuf(b *testing.B) {
+func BenchmarkPublishProtobufStruct(b *testing.B) {
+        // stop benchmark for set-up
+        b.StopTimer()
+
         s := test.RunDefaultServer()
         defer s.Shutdown()
 
@@ -67,6 +70,9 @@ func BenchmarkProtobuf(b *testing.B) {
                 }
                 ch <- true
         })
+
+        // resume benchmark
+        b.StartTimer()
 
         for n := 0; n < b.N; n++ {
                 ec.Publish("protobuf_test", me)

--- a/encoders/protobuf/protobuf_test.go
+++ b/encoders/protobuf/protobuf_test.go
@@ -11,19 +11,6 @@ import (
         pb "github.com/nats-io/nats/encoders/protobuf/testdata"
 )
 
-func BenchmarkProtobufMarshalStruct(b *testing.B) {
-        me := &pb.Person{Name: "derek", Age: 22, Address: "140 New Montgomery St"}
-        me.Children = make(map[string]*pb.Person)
-
-        me.Children["sam"] = &pb.Person{Name: "sam", Age: 19, Address: "140 New Montgomery St"}
-        me.Children["meg"] = &pb.Person{Name: "meg", Age: 17, Address: "140 New Montgomery St"}
-
-        encoder := &protobuf.ProtobufEncoder{}
-        if _, err := encoder.Encode("protobuf_test", me); err != nil {
-                b.Fatalf("Couldn't serialize object", err)
-        }
-}
-
 func NewProtoEncodedConn(tl test.TestLogger) *nats.EncodedConn {
         ec, err := nats.NewEncodedConn(test.NewDefaultConnection(tl), protobuf.PROTOBUF_ENCODER)
         if err != nil {
@@ -57,6 +44,21 @@ func TestProtoMarshalStruct(t *testing.T) {
 	ec.Publish("protobuf_test", me)
 	if e := test.Wait(ch); e != nil {
 		t.Fatal("Did not receive the message")
+        }
+}
+
+func BenchmarkProtobufMarshalStruct(b *testing.B) {
+        me := &pb.Person{Name: "derek", Age: 22, Address: "140 New Montgomery St"}
+        me.Children = make(map[string]*pb.Person)
+
+        me.Children["sam"] = &pb.Person{Name: "sam", Age: 19, Address: "140 New Montgomery St"}
+        me.Children["meg"] = &pb.Person{Name: "meg", Age: 17, Address: "140 New Montgomery St"}
+
+        encoder := &protobuf.ProtobufEncoder{}
+        for n := 0; n < b.N; n++ {
+                if _, err := encoder.Encode("protobuf_test", me); err != nil {
+                        b.Fatalf("Couldn't serialize object", err)
+                }
         }
 }
 

--- a/encoders/protobuf/protobuf_test.go
+++ b/encoders/protobuf/protobuf_test.go
@@ -62,7 +62,6 @@ func BenchmarkProtobuf(b *testing.B) {
         me.Children["meg"] = &pb.Person{Name: "meg", Age: 17, Address: "140 New Montgomery St"}
 
         ec.Subscribe("protobuf_test", func(p *pb.Person) {
-                ch <- true
                 if !reflect.DeepEqual(p, me) {
                         b.Fatalf("Did not receive the correct protobuf response")
                 }

--- a/encoders/protobuf/protobuf_test.go
+++ b/encoders/protobuf/protobuf_test.go
@@ -11,10 +11,10 @@ import (
 	pb "github.com/nats-io/nats/encoders/protobuf/testdata"
 )
 
-func NewProtoEncodedConn(t *testing.T) *nats.EncodedConn {
-	ec, err := nats.NewEncodedConn(test.NewDefaultConnection(t), protobuf.PROTOBUF_ENCODER)
+func NewProtoEncodedConn(tl test.TestLogger) *nats.EncodedConn {
+        ec, err := nats.NewEncodedConn(test.NewDefaultConnection(tl), protobuf.PROTOBUF_ENCODER)
 	if err != nil {
-		t.Fatalf("Failed to create an encoded connection: %v\n", err)
+                tl.Fatalf("Failed to create an encoded connection: %v\n", err)
 	}
 	return ec
 }
@@ -45,4 +45,34 @@ func TestProtoMarshalStruct(t *testing.T) {
 	if e := test.Wait(ch); e != nil {
 		t.Fatal("Did not receive the message")
 	}
+}
+
+func BenchmarkProtobuf(b *testing.B) {
+        s := test.RunDefaultServer()
+        defer s.Shutdown()
+
+        ec := NewProtoEncodedConn(b)
+        defer ec.Close()
+        ch := make(chan bool)
+
+        me := &pb.Person{Name: "derek", Age: 22, Address: "140 New Montgomery St"}
+        me.Children = make(map[string]*pb.Person)
+
+        me.Children["sam"] = &pb.Person{Name: "sam", Age: 19, Address: "140 New Montgomery St"}
+        me.Children["meg"] = &pb.Person{Name: "meg", Age: 17, Address: "140 New Montgomery St"}
+
+        ec.Subscribe("protobuf_test", func(p *pb.Person) {
+                ch <- true
+                if !reflect.DeepEqual(p, me) {
+                        b.Fatalf("Did not receive the correct protobuf response")
+                }
+                ch <- true
+        })
+
+        for n := 0; n < b.N; n++ {
+                ec.Publish("protobuf_test", me)
+                if e := test.Wait(ch); e != nil {
+                        b.Fatal("Did not receive the message")
+                }
+        }
 }

--- a/encoders/protobuf/protobuf_test.go
+++ b/encoders/protobuf/protobuf_test.go
@@ -8,12 +8,25 @@ import (
 	"github.com/nats-io/nats/test"
 
 	"github.com/nats-io/nats/encoders/protobuf"
-	pb "github.com/nats-io/nats/encoders/protobuf/testdata"
+        pb "github.com/nats-io/nats/encoders/protobuf/testdata"
 )
+
+func BenchmarkProtobufMarshalStruct(b *testing.B) {
+        me := &pb.Person{Name: "derek", Age: 22, Address: "140 New Montgomery St"}
+        me.Children = make(map[string]*pb.Person)
+
+        me.Children["sam"] = &pb.Person{Name: "sam", Age: 19, Address: "140 New Montgomery St"}
+        me.Children["meg"] = &pb.Person{Name: "meg", Age: 17, Address: "140 New Montgomery St"}
+
+        encoder := &protobuf.ProtobufEncoder{}
+        if _, err := encoder.Encode("protobuf_test", me); err != nil {
+                b.Fatalf("Couldn't serialize object", err)
+        }
+}
 
 func NewProtoEncodedConn(tl test.TestLogger) *nats.EncodedConn {
         ec, err := nats.NewEncodedConn(test.NewDefaultConnection(tl), protobuf.PROTOBUF_ENCODER)
-	if err != nil {
+        if err != nil {
                 tl.Fatalf("Failed to create an encoded connection: %v\n", err)
 	}
 	return ec

--- a/test/test.go
+++ b/test/test.go
@@ -19,6 +19,8 @@ type tLogger interface {
 	Errorf(format string, args ...interface{})
 }
 
+type TestLogger tLogger
+
 // Dumb wait program to sync on callbacks, etc... Will timeout
 func Wait(ch chan bool) error {
 	return WaitTime(ch, 500*time.Millisecond)


### PR DESCRIPTION
```
$ go test -bench=. -benchmem github.com/nats-io/nats/encoders/{builtin,protobuf}
PASS
BenchmarkGobMarshalStruct-4 	   20000	     67841 ns/op	    9431 B/op	     204 allocs/op
BenchmarkJsonMarshalStruct-4	   50000	     23620 ns/op	    2531 B/op	      41 allocs/op
ok  	github.com/nats-io/nats/encoders/builtin	3.863s
PASS
BenchmarkProtobuf-4	  100000	     16275 ns/op	    1866 B/op	      46 allocs/op
ok  	github.com/nats-io/nats/encoders/protobuf	1.869s
```