### PR TITLE
Don't fail to publish subsequent messages after sending one that's too big

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1202,10 +1202,8 @@ func (nc *Conn) publish(subj, reply string, data []byte) error {
 	var msgSize int64
 	msgSize = int64(len(data))
 	if msgSize > nc.info.MaxPayload {
-		nc.err = ErrMaxPayload
-		err := nc.err
 		nc.mu.Unlock()
-		return err
+		return ErrMaxPayload
 	}
 
 	if nc.isClosed() {

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -279,4 +279,8 @@ func TestErrOnMaxPayloadLimit(t *testing.T) {
 	if err != nats.ErrMaxPayload {
 		t.Fatalf("Expected to fail trying to send more than max payload, got: %s", err)
 	}
+	err = nc.Publish("hello", []byte("a"))
+	if err != nil {
+		t.Fatalf("Expected to succeed trying to send less than max payload, got: %s", err)
+	}
 }


### PR DESCRIPTION
We have some messages that might be quite large.  Publishing any of these causes the connection to never send a message again, because publish() checks nc.err != nil and then bails.  ErrMaxPayload is only relevant to the individual message, it shouldn't make the whole connection bad.