### PR TITLE
Fix behavior of connect on Authentication failure

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1168,10 +1168,13 @@ func (nc *Conn) processErr(e string) {
 	if e == STALE_CONNECTION {
 		nc.processOpErr(ErrStaleConnection)
 	} else {
+		var doCbs = true
+
 		nc.mu.Lock()
 		nc.err = errors.New("nats: " + e)
+		doCbs = (nc.status != CONNECTING)
 		nc.mu.Unlock()
-		nc.Close()
+		nc.close(CLOSED, doCbs)
 	}
 }
 


### PR DESCRIPTION
When connecting to a server with incorrect user name and/or password the server sends an error message. When processing this error, we should close the connection without invoking the callbacks.