### PR TITLE
Fix waitForExits blocking when flush channel is full

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -459,7 +459,10 @@ func (nc *Conn) makeTLSConn() {
 // be shutdown before proceeding.
 func (nc *Conn) waitForExits() {
 	// Kick old flusher forcefully.
-	nc.fch <- true
+	select {
+	case nc.fch <- true:
+	default:
+	}
 
 	//	nc.fch <- true
 	// Wait for any previous go routines.


### PR DESCRIPTION
When a disconnect occurs, the flusher will exit but there may be still multiple calls to kickFlusher() that would cause the flush channel to be full (created buffered with length 1024). When that occurs and spinUpSocketWatchers starts and calls waitForExits, the call to nc.fch <- true would block because the channel is full and nothing is empting it. That would cause the reconnect process to "fail" blocking in spinUpSocketWatchers.