### PR TITLE
Fix test TestFullFlushChanDuringReconnect

### DIFF
--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -462,6 +462,7 @@ func TestFullFlushChanDuringReconnect(t *testing.T) {
 
 	// Restart the server
 	ts = startReconnectServer(t)
+	defer ts.Shutdown()
 
 	// Wait for the reconnect CB to be invoked (but not for too long)
 	if e := WaitTime(reconnectch, 5*time.Second); e != nil {


### PR DESCRIPTION
This test was created for PR https://github.com/nats-io/nats/pull/85

Forgot to shutdown the server at the end of that test, which would prevent new tests after this one to run properly when using server on port 222222