### PR TITLE
"Fix" some tests.

### DIFF
--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -209,8 +209,8 @@ func TestQueueSubscriber(t *testing.T) {
 		t.Fatal("Received too many messages for multiple queue subscribers")
 	}
 	// Drain messages
-	s1.NextMsg(0)
-	s2.NextMsg(0)
+	s1.NextMsg(1000)
+	s2.NextMsg(1000)
 
 	total := 1000
 	for i := 0; i < total; i++ {

--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -132,7 +132,7 @@ func TestBasicReconnectFunctionality(t *testing.T) {
 	}
 
 	expectedReconnectCount := uint64(1)
-	if ec.Conn.Reconnects != expectedReconnectCount {
+	if ec.Conn.Stats().Reconnects != expectedReconnectCount {
 		t.Fatalf("Reconnect count incorrect: %d vs %d\n",
 			ec.Conn.Reconnects, expectedReconnectCount)
 	}


### PR DESCRIPTION
It looks like the default connect timeout of 2 seconds sometimes cause Travis build to fail. Not changing it at this time, but may have to do something special for Travis.