### PR TITLE
Fix some tests for RACE and with GOMAXPROCS=1

### DIFF
--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -209,8 +209,8 @@ func TestQueueSubscriber(t *testing.T) {
 		t.Fatal("Received too many messages for multiple queue subscribers")
 	}
 	// Drain messages
-	s1.NextMsg(0)
-	s2.NextMsg(0)
+	s1.NextMsg(time.Second)
+	s2.NextMsg(time.Second)
 
 	total := 1000
 	for i := 0; i < total; i++ {

--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -131,10 +131,18 @@ func TestBasicReconnectFunctionality(t *testing.T) {
 		t.Fatal("Did not receive our message")
 	}
 
+	// This test fails sometimes on Travis with '0 vs 1', which is weird.
+	// If we are here, that means that the message published while we
+	// were disconnected has been properly flushed and we have receive that
+	// message. Conn.Reconnects is updated *before* the content of the
+	// pending buffer is flushed, so it cannot be 0 at this point...
+
 	expectedReconnectCount := uint64(1)
-	if ec.Conn.Reconnects != expectedReconnectCount {
+	reconnectCount := ec.Conn.Stats().Reconnects
+
+	if reconnectCount != expectedReconnectCount {
 		t.Fatalf("Reconnect count incorrect: %d vs %d\n",
-			ec.Conn.Reconnects, expectedReconnectCount)
+			reconnectCount, expectedReconnectCount)
 	}
 	nc.Close()
 }

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -160,7 +160,12 @@ func TestSlowSubscriber(t *testing.T) {
 	nc := NewDefaultConnection(t)
 	defer nc.Close()
 
+	// Make the sub channel length small so that it reduces the risk of failure
+	// when running with GOMAXPROCS=1
+	nc.Opts.SubChanLen = 100
+
 	sub, _ := nc.SubscribeSync("foo")
+
 	for i := 0; i < (nc.Opts.SubChanLen + 100); i++ {
 		nc.Publish("foo", []byte("Hello"))
 	}
@@ -186,6 +191,10 @@ func TestSlowAsyncSubscriber(t *testing.T) {
 	defer nc.Close()
 
 	bch := make(chan bool)
+
+	// Make the sub channel length small so that it reduces the risk of failure
+	// when running with GOMAXPROCS=1
+	nc.Opts.SubChanLen = 100
 
 	nc.Subscribe("foo", func(_ *nats.Msg) {
 		// block to back us up..


### PR DESCRIPTION
* Some tests would fail with GOMAXPROCS=1 in that the SubChanLen would not get a chance to be full
* Got a RACE report when manipulating nc.ps from the test code