### PR TITLE
Change default wait for tests

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -678,11 +678,13 @@ func (nc *Conn) sendConnect() error {
 		nc.mu.Unlock()
 		return err
 	}
+
+	timeout := nc.Opts.Timeout
 	nc.mu.Unlock()
 
 	nc.sendProto(cProto)
 
-	if err := nc.FlushTimeout(DefaultTimeout); err != nil {
+	if err := nc.FlushTimeout(timeout); err != nil {
 		return err
 	}
 

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -84,6 +84,7 @@ func TestAuthServers(t *testing.T) {
 	opts := nats.DefaultOptions
 	opts.NoRandomize = true
 	opts.Servers = plainServers
+	opts.Timeout = 5 * time.Second
 	_, err := opts.Connect()
 
 	if err == nil {

--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -66,7 +66,7 @@ func TestReconnectAllowedFlags(t *testing.T) {
 
 	// We want wait to timeout here, and the connection
 	// should not trigger the Close CB.
-	if e := Wait(ch); e == nil {
+	if e := WaitTime(ch, 500*time.Millisecond); e == nil {
 		t.Fatal("Triggered ClosedCB incorrectly")
 	}
 	if !nc.IsReconnecting() {
@@ -114,7 +114,7 @@ func TestBasicReconnectFunctionality(t *testing.T) {
 	opts.DisconnectedCB = func(_ *nats.Conn) {
 		dch <- true
 	}
-	Wait(dch)
+	WaitTime(dch, 500*time.Millisecond)
 
 	if err := ec.Publish("foo", testString); err != nil {
 		t.Fatalf("Failed to publish message: %v\n", err)

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -161,13 +161,16 @@ func TestSlowSubscriber(t *testing.T) {
 	defer nc.Close()
 
 	// Make the sub channel length small so that it reduces the risk of failure
-	// when running with GOMAXPROCS=1
+	// when running with GOMAXPROCS=1 (the server would disconnect the client as
+	// a slow consumer). Alternatively, leave SubChanLen alone, but uncomment the
+	// line in the publish loop).
 	nc.Opts.SubChanLen = 100
 
 	sub, _ := nc.SubscribeSync("foo")
 
 	for i := 0; i < (nc.Opts.SubChanLen + 100); i++ {
 		nc.Publish("foo", []byte("Hello"))
+		//		runtime.Gosched()
 	}
 	timeout := 5 * time.Second
 	start := time.Now()
@@ -193,7 +196,9 @@ func TestSlowAsyncSubscriber(t *testing.T) {
 	bch := make(chan bool)
 
 	// Make the sub channel length small so that it reduces the risk of failure
-	// when running with GOMAXPROCS=1
+	// when running with GOMAXPROCS=1 (the server would disconnect the client as
+	// a slow consumer). Alternatively, leave SubChanLen alone, but uncomment the
+	// line in the publish loop).
 	nc.Opts.SubChanLen = 100
 
 	nc.Subscribe("foo", func(_ *nats.Msg) {
@@ -202,6 +207,7 @@ func TestSlowAsyncSubscriber(t *testing.T) {
 	})
 	for i := 0; i < (nc.Opts.SubChanLen + 100); i++ {
 		nc.Publish("foo", []byte("Hello"))
+		//		runtime.Gosched()
 	}
 	timeout := 5 * time.Second
 	start := time.Now()

--- a/test/test.go
+++ b/test/test.go
@@ -21,7 +21,7 @@ type tLogger interface {
 
 // Dumb wait program to sync on callbacks, etc... Will timeout
 func Wait(ch chan bool) error {
-	return WaitTime(ch, 500*time.Millisecond)
+	return WaitTime(ch, 5*time.Second)
 }
 
 func WaitTime(ch chan bool, timeout time.Duration) error {


### PR DESCRIPTION
I think that those changes may help prevent random build failures on Travis. Note that the change to the test's Wait() function is something to keep in mind when writing new tests, if those tests rely on Wait() to timeout quickly. You should then use the WaitTime() version that allows you to set a small timeout.

cc @derekcollison 