### PR TITLE
"Synchronous" connect and reconnect

### DIFF
--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/nats-io/gnatsd/auth"
 	gnatsd "github.com/nats-io/gnatsd/test"
@@ -63,4 +64,72 @@ func TestAuthFailNoDisconnectCB(t *testing.T) {
 	if atomic.LoadInt32(&receivedDisconnectCB) > 0 {
 		t.Fatal("Should not have received a disconnect callback on auth failure")
 	}
+}
+
+func TestAuthFailAllowReconnect(t *testing.T) {
+
+	ts := startReconnectServer(t)
+	defer ts.Shutdown()
+
+	var servers = []string{
+		"nats://localhost:22222",
+		"nats://localhost:22223",
+		"nats://localhost:22224",
+	}
+
+	srvOpts := gnatsd.DefaultTestOptions
+	srvOpts.Port = 22223
+	ts2 := RunServerWithOptions(srvOpts)
+
+	// Auth is pluggable, so need to set here..
+	auth := &auth.Plain{
+		Username: "ivan",
+		Password: "foo",
+	}
+	ts2.SetAuthMethod(auth)
+	defer ts2.Shutdown()
+
+	ts3 := RunServerOnPort(22224)
+	defer ts3.Shutdown()
+
+	reconnectch := make(chan bool)
+
+	opts := nats.DefaultOptions
+	opts.Servers = servers
+	opts.AllowReconnect = true
+	opts.NoRandomize = true
+	opts.MaxReconnect = 10
+	opts.ReconnectWait = 100 * time.Millisecond
+
+	opts.ReconnectedCB = func(_ *nats.Conn) {
+		reconnectch <- true
+	}
+
+	// Connect
+	nc, err := opts.Connect()
+	if err != nil {
+		t.Fatalf("Should have connected ok: %v", err)
+	}
+
+	// Stop the server
+	ts.Shutdown()
+
+	// The client will try to connect to the second server, and that
+	// should fail. It should then try to connect to the third and succeed.
+
+	// Wait for the reconnect CB.
+	if e := WaitTime(reconnectch, 5*time.Second); e != nil {
+		t.Fatal("Reconnect callback should not have been triggered")
+	}
+
+	if nc.IsClosed() {
+		t.Fatal("Should have reconnected")
+	}
+
+	if nc.ConnectedUrl() != servers[2] {
+		t.Fatalf("Should have reconnected to %s, reconnected to %s instead", servers[2], nc.ConnectedUrl())
+	}
+
+	// Close the connection
+	nc.Close()
 }

--- a/test/netchan_test.go
+++ b/test/netchan_test.go
@@ -204,6 +204,9 @@ func TestRecvChanAsyncLeakGoRoutines(t *testing.T) {
 	ec := NewEConn(t)
 	defer ec.Close()
 
+	// Call this to make sure that we have everything setup connection wise
+	ec.Flush()
+
 	before := runtime.NumGoroutine()
 
 	ch := make(chan int)
@@ -234,6 +237,9 @@ func TestRecvChanLeakGoRoutines(t *testing.T) {
 
 	ec := NewEConn(t)
 	defer ec.Close()
+
+	// Call this to make sure that we have everything setup connection wise
+	ec.Flush()
 
 	before := runtime.NumGoroutine()
 

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -20,6 +20,9 @@ func TestServerAutoUnsub(t *testing.T) {
 	received := int32(0)
 	max := int32(10)
 
+	// Call this to make sure that we have everything setup connection wise
+	nc.Flush()
+
 	base := runtime.NumGoroutine()
 
 	sub, err := nc.Subscribe("foo", func(_ *nats.Msg) {


### PR DESCRIPTION
This is changing the behavior of the connect and reconnect mechanism to do things synchronously, under the session lock. This would solve issues #68 and #87.