### PR TITLE
Updated the usage statment to remove unneeded arg.

### DIFF
--- a/examples/nats-pub.go
+++ b/examples/nats-pub.go
@@ -12,7 +12,7 @@ import (
 )
 
 func usage() {
-	log.Fatalf("Usage: nats-pub [-s server] [--ssl] [-t] <subject> <msg> \n")
+  log.Fatalf("Usage: nats-pub [-s server (%s)] [--ssl] <subject> <msg> \n", nats.DefaultURL)
 }
 
 func main() {


### PR DESCRIPTION
* I removed the -t (not used in the publish example)
* I added the print of the nats.DefaultURL to clarify server spec.