### PR TITLE
Added a queueing subscriber to the example programs

### DIFF
--- a/examples/nats-qsub.go
+++ b/examples/nats-qsub.go
@@ -1,0 +1,63 @@
+// Copyright 2012-2015 Apcera Inc. All rights reserved.
+// +build ignore
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/nats-io/nats"
+)
+
+func usage() {
+	log.Fatalf("Usage: nats-sub [-s server] [--ssl] [-t] <subject> <queue-group>\n")
+}
+
+func printMsg(m *nats.Msg, i int) {
+	log.Printf("[#%d] Received on [%s] Queue[%s] Pid[%d]: '%s'\n", i, m.Subject, m.Sub.Queue, os.Getpid(), string(m.Data))
+}
+
+func main() {
+	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+	var showTime = flag.Bool("t", false, "Display timestamps")
+	var ssl = flag.Bool("ssl", false, "Use Secure Connection")
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) < 2 {
+		usage()
+	}
+
+	opts := nats.DefaultOptions
+	opts.Servers = strings.Split(*urls, ",")
+	for i, s := range opts.Servers {
+		opts.Servers[i] = strings.Trim(s, " ")
+	}
+	opts.Secure = *ssl
+
+	nc, err := opts.Connect()
+	if err != nil {
+		log.Fatalf("Can't connect: %v\n", err)
+	}
+
+	subj, queue, i := args[0], args[1], 0
+
+	nc.QueueSubscribe(subj, queue, func(msg *nats.Msg) {
+		i += 1
+		printMsg(msg, i)
+	})
+
+	log.Printf("Listening on [%s]\n", subj)
+	if *showTime {
+		log.SetFlags(log.LstdFlags)
+	}
+
+	runtime.Goexit()
+}

--- a/examples/nats-req.go
+++ b/examples/nats-req.go
@@ -1,0 +1,53 @@
+// Copyright 2012-2015 Apcera Inc. All rights reserved.
+// +build ignore
+
+package main
+
+import (
+	"flag"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats"
+)
+
+func usage() {
+	log.Fatalf("Usage: nats-req [-s server (%s)] [--ssl] <subject> <msg> \n", nats.DefaultURL)
+}
+
+func main() {
+	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+	var ssl = flag.Bool("ssl", false, "Use Secure Connection")
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) < 2 {
+		usage()
+	}
+
+	opts := nats.DefaultOptions
+	opts.Servers = strings.Split(*urls, ",")
+	for i, s := range opts.Servers {
+		opts.Servers[i] = strings.Trim(s, " ")
+	}
+
+	opts.Secure = *ssl
+
+	nc, err := opts.Connect()
+	if err != nil {
+		log.Fatalf("Can't connect: %v\n", err)
+	}
+	defer nc.Close()
+	subj, payload := args[0], []byte(args[1])
+
+	msg, err := nc.Request(subj, []byte(payload), 1000*time.Millisecond)
+	if err != nil {
+		log.Fatalf("Error in Request: %v\n", err)
+	}
+	log.Printf("Published [%s] : '%s'\n", subj, payload)
+	log.Printf("Received [%v] : '%s'\n", msg.Subject, string(msg.Data))
+}

--- a/examples/nats-rply.go
+++ b/examples/nats-rply.go
@@ -1,0 +1,63 @@
+// Copyright 2012-2015 Apcera Inc. All rights reserved.
+// +build ignore
+
+package main
+
+import (
+	"flag"
+	"log"
+	"runtime"
+	"strings"
+
+	"github.com/nats-io/nats"
+)
+
+func usage() {
+	log.Fatalf("Usage: nats-rply [-s server] [--ssl] [-t] <subject> <reponse>\n")
+}
+
+func printMsg(m *nats.Msg, i int) {
+	log.Printf("[#%d] Received on [%s]: '%s'\n", i, m.Subject, string(m.Data))
+}
+
+func main() {
+	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+	var showTime = flag.Bool("t", false, "Display timestamps")
+	var ssl = flag.Bool("ssl", false, "Use Secure Connection")
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) < 2 {
+		usage()
+	}
+
+	opts := nats.DefaultOptions
+	opts.Servers = strings.Split(*urls, ",")
+	for i, s := range opts.Servers {
+		opts.Servers[i] = strings.Trim(s, " ")
+	}
+	opts.Secure = *ssl
+
+	nc, err := opts.Connect()
+	if err != nil {
+		log.Fatalf("Can't connect: %v\n", err)
+	}
+
+	subj, reply, i := args[0], args[1], 0
+
+	nc.Subscribe(subj, func(msg *nats.Msg) {
+		i += 1
+		printMsg(msg, i)
+		nc.Publish(msg.Reply, []byte(reply))
+	})
+
+	log.Printf("Listening on [%s]\n", subj)
+	if *showTime {
+		log.SetFlags(log.LstdFlags)
+	}
+
+	runtime.Goexit()
+}


### PR DESCRIPTION
Created a nats-qsub.go example. Main difference from nats-sub.go is that I called QueueSubscribe and printed out the queue name as well as the pid of the executable in the printMsg function for demonstration purposes otherwise it's identical to nats-sub.go

Changes:
*Second argument is queue name. 
*Subscribe call is to QueueSubscribe
*printMsg prints 2 additional pieces of information. queue name and process id. 