### PR TITLE
Fix 64bit alignment of Conn.ssid, to avoid crash

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -136,6 +136,12 @@ const (
 // []byte payloads.
 type Conn struct {
 	Statistics
+
+	// Keep ssid as first element of the struct to guarantee
+	// 64bit alignment. atomic.* functions crash on 32bit machines if operand is not
+	// aligned at 64bit. See https://github.com/golang/go/issues/599
+	ssid    int64
+
 	mu      sync.Mutex
 	Opts    Options
 	wg      sync.WaitGroup
@@ -146,8 +152,6 @@ type Conn struct {
 	pending *bytes.Buffer
 	fch     chan bool
 	info    serverInfo
-	_       uint32 // needed to correctly align the following ssid field on i386 systems
-	ssid    int64
 	subs    map[int64]*Subscription
 	mch     chan *Msg
 	pongs   []chan bool


### PR DESCRIPTION
atomic.* functions crash on 32bit systems (i386, armhf) if the value is not 64bit aligned. Despite the comment in the code, Conn.ssid is not aligned correctly and crash on armhf. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x4 pc=0x15ef18]

goroutine 1 [running]:
sync/atomic.addUint64(0x1053cef4, 0x1, 0x0, 0x1, 0x0)
	/usr/lib/go/src/sync/atomic/64bit_arm.go:31 +0x70
github.com/nats-io/nats.(*Conn).subscribe(0x1053ce00, 0x260248, 0x5, 0x0, 0x0, 0x10537340, 0x10000, 0x0, 0x0, 0x0)
	/home/domain/longsleep/go/src/github.com/nats-io/nats/nats.go:1372 +0x300
github.com/nats-io/nats.(*EncodedConn).subscribe(0x1052e6b0, 0x260248, 0x5, 0x0, 0x0, 0x2050a0, 0x1050a3b8, 0x234088, 0x0, 0x0)
	/home/domain/longsleep/go/src/github.com/nats-io/nats/enc.go:224 +0x39c
github.com/nats-io/nats.(*EncodedConn).Subscribe(0x1052e6b0, 0x260248, 0x5, 0x2050a0, 0x1050a3b8, 0x179e0, 0x0, 0x0)
	/home/domain/longsleep/go/src/github.com/nats-io/nats/enc.go:163 +0x64
```

This PR fixes the problem, by moving the ssid struct definition to the top, as the first element is always 64bit aligned.