### PR TITLE
Clean up logic around max handling to regress

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1031,8 +1031,8 @@ func (nc *Conn) deliverMsgs(s *Subscription) {
 		s.mu.Unlock()
 
 		// Use the same semantics everywhere for delivered
-		// Increments... I know this is in a lock vs. elsewhere
-		// Is this less racing???
+		// Increments... This was in the lock above but race
+		// checks were failing.
 		delivered = atomic.AddUint64(&s.delivered, 1)
 
 		if closed {

--- a/nats.go
+++ b/nats.go
@@ -1028,10 +1028,12 @@ func (nc *Conn) deliverMsgs(s *Subscription) {
 		s.mu.Lock()
 		max = s.max
 		closed = s.closed
+		s.mu.Unlock()
+
 		// Use the same semantics everywhere for delivered
 		// Increments... I know this is in a lock vs. elsewhere
+		// Is this less racing???
 		delivered = atomic.AddUint64(&s.delivered, 1)
-		s.mu.Unlock()
 
 		if closed {
 			break


### PR DESCRIPTION
I'm trying to test changes against my new Java client and believe that this is a little cleaner and fixes some edge race conditions. There are several more and not sure that these changes should be applied until a wider look at delivered/max logic is looked at here...