### PR TITLE
Removed ineffective nc.err settings

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -778,11 +778,6 @@ func (nc *Conn) processDisconnect() {
 	if nc.err != nil {
 		return
 	}
-	if nc.info.TLSRequired {
-		nc.err = ErrSecureConnRequired
-	} else {
-		nc.err = ErrConnectionClosed
-	}
 }
 
 // flushReconnectPending will push the pending items that were


### PR DESCRIPTION
The affected lines set nc.err, but the calling function immediately reassigns nc.err, rendering these statements useless.