### PR TITLE
Fix handling of Verbose option during connect/reconnect

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -725,6 +725,15 @@ func (nc *Conn) sendConnect() error {
 		return err
 	}
 
+	// If opts.Verbose is set, handle +OK
+	if nc.Opts.Verbose && strings.HasPrefix(line, _OK_OP_) {
+		// Read the rest now...
+		line, err = br.ReadString('\n')
+		if err != nil {
+			return err
+		}
+	}
+
 	// We expect a PONG
 	if line != pongProto {
 		// But it could be something else, like -ERR

--- a/nats.go
+++ b/nats.go
@@ -304,6 +304,7 @@ const (
 	pubProto   = "PUB %s %s %d" + _CRLF_
 	subProto   = "SUB %s %s %d" + _CRLF_
 	unsubProto = "UNSUB %d %s" + _CRLF_
+	okProto    = _OK_OP_ + _CRLF_
 )
 
 func (nc *Conn) debugPool(str string) {
@@ -726,7 +727,7 @@ func (nc *Conn) sendConnect() error {
 	}
 
 	// If opts.Verbose is set, handle +OK
-	if nc.Opts.Verbose && strings.HasPrefix(line, _OK_OP_) {
+	if nc.Opts.Verbose && line == okProto {
 		// Read the rest now...
 		line, err = br.ReadString('\n')
 		if err != nil {

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -298,3 +298,17 @@ func TestErrOnMaxPayloadLimit(t *testing.T) {
 		t.Fatalf("Expected to succeed trying to send less than max payload, got: %s", err)
 	}
 }
+
+func TestConnectVerbose(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	o := nats.DefaultOptions
+	o.Verbose = true
+
+	nc, err := o.Connect()
+	if err != nil {
+		t.Fatalf("Should have connected ok: %v", err)
+	}
+	nc.Close()
+}


### PR DESCRIPTION
* Since the (re)connect process was made synchronous, we now need to handle the possible return of +OK by the server.