### PR TITLE
Fixes issue where nats connection cannot be made

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -737,13 +737,13 @@ func (nc *Conn) sendConnect() error {
 		}
 	}
 
-	// We expect a PONG
-	if line != pongProto {
-		// But it could be something else, like -ERR
-		if strings.HasPrefix(line, _ERR_OP_) {
-			return errors.New("nats: " + strings.TrimPrefix(line, _ERR_OP_))
-		}
-
+	// We expect a PONG, the +OK line is also fine
+	switch {
+	case line == pongProto, strings.HasPrefix(line, _OK_OP_):
+		break
+	case strings.HasPrefix(line, _ERR_OP_):
+		return errors.New("nats: " + strings.TrimPrefix(line, _ERR_OP_))
+	default:
 		return errors.New("nats: " + line)
 	}
 


### PR DESCRIPTION
Running into issues connecting to a locally hosted nats server, which is run with nats gem:
`nats (0.5.1)` on OS X: `10.9.5`. This is due to a `+OK` line being returned as opposed to the other pre-selected
errors, which should be permissible.
