### PR TITLE
Fix error in next message after encode/decode fail in previous

### DIFF
--- a/enc_test.go
+++ b/enc_test.go
@@ -28,17 +28,13 @@ func TestPublishErrorAfterSubscribeDecodeError(t *testing.T) {
 	nc, _ := opts.Connect()
 	defer nc.Close()
 	c, _ := NewEncodedConn(nc, JSON_ENCODER)
-
 	type Message struct {
 		Message string
 	}
 	const testSubj = "test"
 
 	c.Subscribe(testSubj, func(msg *Message) {})
-
-	//Sending invalid json message
 	c.Publish(testSubj, `foo`)
-
 	c.Flush()
 	if err := c.Publish(testSubj, Message{"2"}); err != nil {
 		t.Error("Fail to send correct json message after decode error in subscription")
@@ -52,12 +48,9 @@ func TestPublishErrorAfterInvalidPublishMessage(t *testing.T) {
 	nc, _ := opts.Connect()
 	defer nc.Close()
 	c, _ := NewEncodedConn(nc, protobuf.PROTOBUF_ENCODER)
-
 	const testSubj = "test"
 
 	c.Publish(testSubj, &testdata.Person{Name: "Anatolii"})
-
-	//Sending invalid protobuf message
 	c.Publish(testSubj, "foo")
 	if err := c.Publish(testSubj, &testdata.Person{Name: "Anatolii"}); err != nil {
 		t.Error("Fail to send correct json message after invalid message publishing", err)

--- a/enc_test.go
+++ b/enc_test.go
@@ -1,0 +1,66 @@
+package nats_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/nats-io/nats"
+	"github.com/nats-io/nats/encoders/protobuf"
+	"github.com/nats-io/nats/encoders/protobuf/testdata"
+)
+
+var options = Options{
+	Url:            "nats://localhost:22222",
+	AllowReconnect: true,
+	MaxReconnect:   10,
+	ReconnectWait:  100 * time.Millisecond,
+	Timeout:        DefaultTimeout,
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Encoded connection tests
+////////////////////////////////////////////////////////////////////////////////
+
+func TestPublishErrorAfterSubscribeDecodeError(t *testing.T) {
+	ts := RunServerOnPort(22222)
+	defer ts.Shutdown()
+	opts := options
+	nc, _ := opts.Connect()
+	defer nc.Close()
+	c, _ := NewEncodedConn(nc, JSON_ENCODER)
+
+	type Message struct {
+		Message string
+	}
+	const testSubj = "test"
+
+	c.Subscribe(testSubj, func(msg *Message) {})
+
+	//Sending invalid json message
+	c.Publish(testSubj, `foo`)
+
+	time.Sleep(100 * time.Millisecond)
+
+	if err := c.Publish(testSubj, Message{"2"}); err != nil {
+		t.Error("Fail to send correct json message after decede error in subscription")
+	}
+}
+
+func TestPublishErrorAfterInvalidPublishMessage(t *testing.T) {
+	ts := RunServerOnPort(22222)
+	defer ts.Shutdown()
+	opts := options
+	nc, _ := opts.Connect()
+	defer nc.Close()
+	c, _ := NewEncodedConn(nc, protobuf.PROTOBUF_ENCODER)
+
+	const testSubj = "test"
+
+	c.Publish(testSubj, testdata.Person{Name: "Anatolii"})
+
+	//Sending invalid protobuf message
+	c.Publish(testSubj, "foo")
+	if err := c.Publish(testSubj, testdata.Person{Name: "Anatolii"}); err != nil {
+		t.Error("Fail to send correct json message after invalid message publishing")
+	}
+}

--- a/enc_test.go
+++ b/enc_test.go
@@ -37,7 +37,7 @@ func TestPublishErrorAfterSubscribeDecodeError(t *testing.T) {
 
 	c.Subscribe(testSubj, func(msg *Message) {})
 
-	//Publishing invalid json to catch decode error in subscription callback
+	//Publish invalid json to catch decode error in subscription callback
 	c.Publish(testSubj, `foo`)
 	c.Flush()
 

--- a/enc_test.go
+++ b/enc_test.go
@@ -39,10 +39,9 @@ func TestPublishErrorAfterSubscribeDecodeError(t *testing.T) {
 	//Sending invalid json message
 	c.Publish(testSubj, `foo`)
 
-	time.Sleep(100 * time.Millisecond)
-
+	c.Flush()
 	if err := c.Publish(testSubj, Message{"2"}); err != nil {
-		t.Error("Fail to send correct json message after decede error in subscription")
+		t.Error("Fail to send correct json message after decode error in subscription")
 	}
 }
 

--- a/enc_test.go
+++ b/enc_test.go
@@ -56,11 +56,11 @@ func TestPublishErrorAfterInvalidPublishMessage(t *testing.T) {
 
 	const testSubj = "test"
 
-	c.Publish(testSubj, testdata.Person{Name: "Anatolii"})
+	c.Publish(testSubj, &testdata.Person{Name: "Anatolii"})
 
 	//Sending invalid protobuf message
 	c.Publish(testSubj, "foo")
-	if err := c.Publish(testSubj, testdata.Person{Name: "Anatolii"}); err != nil {
-		t.Error("Fail to send correct json message after invalid message publishing")
+	if err := c.Publish(testSubj, &testdata.Person{Name: "Anatolii"}); err != nil {
+		t.Error("Fail to send correct json message after invalid message publishing", err)
 	}
 }

--- a/enc_test.go
+++ b/enc_test.go
@@ -28,14 +28,20 @@ func TestPublishErrorAfterSubscribeDecodeError(t *testing.T) {
 	nc, _ := opts.Connect()
 	defer nc.Close()
 	c, _ := NewEncodedConn(nc, JSON_ENCODER)
+
+	//Test message type
 	type Message struct {
 		Message string
 	}
 	const testSubj = "test"
 
 	c.Subscribe(testSubj, func(msg *Message) {})
+
+	//Publishing invalid json to catch decode error in subscription callback
 	c.Publish(testSubj, `foo`)
 	c.Flush()
+
+	//Next publish should be successful
 	if err := c.Publish(testSubj, Message{"2"}); err != nil {
 		t.Error("Fail to send correct json message after decode error in subscription")
 	}
@@ -51,7 +57,11 @@ func TestPublishErrorAfterInvalidPublishMessage(t *testing.T) {
 	const testSubj = "test"
 
 	c.Publish(testSubj, &testdata.Person{Name: "Anatolii"})
+
+	//Publish invalid protobuff message to catch decode error
 	c.Publish(testSubj, "foo")
+
+	//Next publish with valid protobuf message should be successful
 	if err := c.Publish(testSubj, &testdata.Person{Name: "Anatolii"}); err != nil {
 		t.Error("Fail to send correct json message after invalid message publishing", err)
 	}

--- a/encoders/builtin/json_test.go
+++ b/encoders/builtin/json_test.go
@@ -184,9 +184,9 @@ func TestFailedEncodedPublish(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected an error trying to publish a channel")
 	}
-	derr := ec.LastError()
-	if derr.Error() != err.Error() {
-		t.Fatalf("Expected LastError to be same: %q vs %q\n", err, derr)
+	err = ec.LastError()
+	if err != nil {
+		t.Fatalf("Expected LastError to be nil: %q ", err)
 	}
 }
 


### PR DESCRIPTION
This issue was discussed in https://github.com/nats-io/nats/issues/78

I create test cases to reproduce errors
You can checkout this commit with failed tests https://github.com/AnatoliiPrylutskyi/nats/commit/3d9148470958d898ffa705cee5894a018c8f7d29

Also I remove global errors in places where it cause errors. All tests are green.