### PR TITLE
Remove Channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 # Go client
 go get github.com/nats-io/nats
 
-# Servers
+# Server
 
-# gnatsd
 go get github.com/nats-io/gnatsd
-
-# nats-server (Ruby)
-gem install nats
 ```
 
 ## Basic Usage
@@ -37,8 +33,12 @@ nc.Subscribe("foo", func(m *Msg) {
 sub, err := nc.SubscribeSync("foo")
 m, err := sub.NextMsg(timeout)
 
-// Unsubscribing
-sub, err := nc.Subscribe("foo", nil)
+// Channel Subscriber
+ch := make(chan *nats.Msg, 64)
+sub, err := nc.ChanSubscribe("foo", ch)
+msg <- ch
+
+// Unsubscribe
 sub.Unsubscribe()
 
 // Requests
@@ -82,12 +82,12 @@ c.Subscribe("hello", func(p *person) {
     fmt.Printf("Received a person: %+v\n", p)
 })
 
-me := &person{Name: "derek", Age: 22, Address: "585 Howard Street, San Francisco, CA"}
+me := &person{Name: "derek", Age: 22, Address: "140 New Montgomery Street, San Francisco, CA"}
 
 // Go type Publisher
 c.Publish("hello", me)
 
-// Unsubscribing
+// Unsubscribe
 sub, err := c.Subscribe("foo", nil)
 ...
 sub.Unsubscribe()
@@ -167,7 +167,7 @@ ec.BindRecvChan("hello", recvCh)
 sendCh := make(chan *person)
 ec.BindSendChan("hello", sendCh)
 
-me := &person{Name: "derek", Age: 22, Address: "585 Howard Street"}
+me := &person{Name: "derek", Age: 22, Address: "140 New Montgomery Street"}
 
 // Send via Go channels
 sendCh <- me

--- a/enc.go
+++ b/enc.go
@@ -222,7 +222,7 @@ func (c *EncodedConn) subscribe(subject, queue string, cb Handler) (*Subscriptio
 		cbValue.Call(oV)
 	}
 
-	return c.Conn.subscribe(subject, queue, natsCB, c.Conn.Opts.SubChanLen, nil)
+	return c.Conn.subscribe(subject, queue, natsCB, nil)
 }
 
 // FlushTimeout allows a Flush operation to have an associated timeout.

--- a/enc.go
+++ b/enc.go
@@ -222,7 +222,7 @@ func (c *EncodedConn) subscribe(subject, queue string, cb Handler) (*Subscriptio
 		cbValue.Call(oV)
 	}
 
-	return c.Conn.subscribe(subject, queue, natsCB, c.Conn.Opts.SubChanLen)
+	return c.Conn.subscribe(subject, queue, natsCB, c.Conn.Opts.SubChanLen, nil)
 }
 
 // FlushTimeout allows a Flush operation to have an associated timeout.

--- a/examples/nats-bench.go
+++ b/examples/nats-bench.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -81,7 +82,7 @@ func main() {
 	if *numSubs > 0 {
 		total *= float64(*numSubs)
 	}
-	fmt.Printf("\nNATS throughput is %.f msgs/sec\n", total/delta)
+	fmt.Printf("\nNATS throughput is %s msgs/sec\n", commaFormat(int64(total/delta)))
 }
 
 func runPublisher(startwg, donewg *sync.WaitGroup, opts nats.Options, numMsgs int) {
@@ -127,4 +128,22 @@ func runSubscriber(startwg, donewg *sync.WaitGroup, opts nats.Options, numMsgs i
 	})
 	nc.Flush()
 	startwg.Done()
+}
+
+func commaFormat(n int64) string {
+	in := strconv.FormatInt(n, 10)
+	out := make([]byte, len(in)+(len(in)-2+int(in[0]/'0'))/3)
+	if in[0] == '-' {
+		in, out[0] = in[1:], '-'
+	}
+	for i, j, k := len(in)-1, len(out)-1, 0; ; i, j = i-1, j-1 {
+		out[j] = in[i]
+		if i == 0 {
+			return string(out)
+		}
+		if k++; k == 3 {
+			j, k = j-1, 0
+			out[j] = ','
+		}
+	}
 }

--- a/nats.go
+++ b/nats.go
@@ -1446,11 +1446,9 @@ func (nc *Conn) processErr(e string) {
 	if e == STALE_CONNECTION {
 		nc.processOpErr(ErrStaleConnection)
 	} else {
-		var doCbs = true
-
 		nc.mu.Lock()
 		nc.err = errors.New("nats: " + e)
-		doCbs = (nc.status != CONNECTING)
+		doCbs := (nc.status != CONNECTING)
 		nc.mu.Unlock()
 		nc.close(CLOSED, doCbs)
 	}
@@ -2039,7 +2037,9 @@ func (nc *Conn) FlushTimeout(timeout time.Duration) (err error) {
 			err = ErrConnectionClosed
 		} else {
 			nc.mu.Lock()
-			err = nc.err
+			if nc.err != nil && nc.err != ErrSlowConsumer {
+				err = nc.err
+			}
 			nc.mu.Unlock()
 			close(ch)
 		}

--- a/nats.go
+++ b/nats.go
@@ -195,9 +195,7 @@ type Subscription struct {
 	// only be processed by one member of the group.
 	Queue string
 
-	msgs       uint64
 	dropped    uint64
-	bytes      uint64
 	max        uint64
 	conn       *Conn
 	mcb        MsgHandler
@@ -1291,7 +1289,7 @@ func (nc *Conn) processMsg(data []byte) {
 	sub.mu.Lock()
 
 	// This is a catch all for more than max messages delivered.
-	if sub.max > 0 && sub.msgs > sub.max {
+	if sub.max > 0 && sub.delivered > sub.max {
 		sub.mu.Unlock()
 		nc.removeSub(sub)
 		nc.mu.Unlock()
@@ -1299,9 +1297,6 @@ func (nc *Conn) processMsg(data []byte) {
 	}
 
 	// Sub internal stats
-	sub.msgs++
-	sub.bytes += uint64(len(data))
-
 	sub.pMsgs++
 	sub.pBytes += int64(len(m.Data))
 

--- a/nats_test.go
+++ b/nats_test.go
@@ -69,7 +69,10 @@ func TestReconnectServerStats(t *testing.T) {
 	}
 
 	// Make sure the server who is reconnected has the reconnects stats reset.
+	nc.mu.Lock()
 	_, cur := nc.currentServer()
+	nc.mu.Unlock()
+
 	if cur.reconnects != 0 {
 		t.Fatalf("Current Server's reconnects should be 0 vs %d\n", cur.reconnects)
 	}

--- a/netchan.go
+++ b/netchan.go
@@ -87,5 +87,5 @@ func (c *EncodedConn) bindRecvChan(subject, queue string, channel interface{}) (
 		chVal.Send(oPtr)
 	}
 
-	return c.Conn.subscribe(subject, queue, cb, c.Conn.Opts.SubChanLen)
+	return c.Conn.subscribe(subject, queue, cb, c.Conn.Opts.SubChanLen, nil)
 }

--- a/netchan.go
+++ b/netchan.go
@@ -87,5 +87,5 @@ func (c *EncodedConn) bindRecvChan(subject, queue string, channel interface{}) (
 		chVal.Send(oPtr)
 	}
 
-	return c.Conn.subscribe(subject, queue, cb, c.Conn.Opts.SubChanLen, nil)
+	return c.Conn.subscribe(subject, queue, cb, nil)
 }

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -9,6 +9,7 @@ go test -v -covermode=atomic -coverprofile=./cov/protobuf.out ./encoders/protobu
 go test -v -covermode=atomic -coverprofile=./cov/test.out -coverpkg=github.com/nats-io/nats ./test
 gocovmerge ./cov/*.out > acc.out
 rm -rf ./cov
+
 # If we have an arg, assume travis run and push to coveralls. Otherwise launch browser results
 if [[ -n $1 ]]; then
     $HOME/gopath/bin/goveralls -coverprofile=acc.out -service travis-ci

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -30,7 +30,7 @@ func TestServersOption(t *testing.T) {
 
 	_, err := opts.Connect()
 	if err != nats.ErrNoServers {
-		t.Fatalf("Wrong error: '%s'\n", err)
+		t.Fatalf("Wrong error: '%v'\n", err)
 	}
 	opts.Servers = testServers
 	_, err = opts.Connect()
@@ -74,7 +74,7 @@ func TestServersOption(t *testing.T) {
 func TestNewStyleServersOption(t *testing.T) {
 	_, err := nats.Connect(nats.DefaultURL, nats.DontRandomize())
 	if err != nats.ErrNoServers {
-		t.Fatalf("Wrong error: '%s'\n", err)
+		t.Fatalf("Wrong error: '%v'\n", err)
 	}
 	servers := strings.Join(testServers, ",")
 

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -234,8 +234,8 @@ func TestSlowAsyncSubscriber(t *testing.T) {
 	}
 
 	// Set new limits
-	pml := int64(100)
-	pbl := int64(1024 * 1024)
+	pml := 100
+	pbl := 1024 * 1024
 
 	sub.SetPendingLimits(pml, pbl)
 
@@ -297,7 +297,7 @@ func TestAsyncErrHandler(t *testing.T) {
 	toSend := 100
 
 	// Limit internal subchan length to trip condition easier.
-	sub.SetPendingLimits(int64(limit), 1024)
+	sub.SetPendingLimits(limit, 1024)
 
 	ch := make(chan bool)
 
@@ -336,7 +336,7 @@ func TestAsyncErrHandler(t *testing.T) {
 		t.Fatal("Failed to call async err handler")
 	}
 	// Make sure dropped stats is correct.
-	if d, _ := sub.Dropped(); d != int64(toSend-limit) {
+	if d, _ := sub.Dropped(); d != toSend-limit {
 		t.Fatalf("Expected Dropped to be %d, got %d\n", toSend-limit, d)
 	}
 	if ae := atomic.LoadInt64(&aeCalled); ae != 1 {
@@ -393,7 +393,7 @@ func TestAsyncErrHandlerChanSubscription(t *testing.T) {
 		t.Fatal("Failed to call async err handler")
 	}
 	// Make sure dropped stats is correct.
-	if d, _ := sub.Dropped(); d != int64(toSend-limit) {
+	if d, _ := sub.Dropped(); d != toSend-limit {
 		t.Fatalf("Expected Dropped to be %d, go %d\n", toSend-limit, d)
 	}
 	if ae := atomic.LoadInt64(&aeCalled); ae != 1 {
@@ -656,15 +656,14 @@ func TestAsyncSubscriptionPending(t *testing.T) {
 
 	// New way, make sure the same and check bytes.
 	m, b, _ := sub.Pending()
-	total64 := int64(total)
-	mlen := int64(len(msg))
+	mlen := len(msg)
 
-	if m != total64 && m != total64-1 {
-		t.Fatalf("Expected msgs of %d or %d, got %d\n", total64, total64-1, m)
+	if m != total && m != total-1 {
+		t.Fatalf("Expected msgs of %d or %d, got %d\n", total, total-1, m)
 	}
-	if b != total64*mlen && b != (total64-1)*mlen {
+	if b != total*mlen && b != (total-1)*mlen {
 		t.Fatalf("Expected bytes of %d or %d, got %d\n",
-			total64*mlen, (total64-1)*mlen, b)
+			total*mlen, (total-1)*mlen, b)
 	}
 }
 
@@ -760,14 +759,13 @@ func TestSyncSubscriptionPending(t *testing.T) {
 
 	// New way, make sure the same and check bytes.
 	m, b, _ := sub.Pending()
-	total64 := int64(total)
-	mlen := int64(len(msg))
+	mlen := len(msg)
 
-	if m != total64 {
-		t.Fatalf("Expected msgs of %d, got %d\n", total64, m)
+	if m != total {
+		t.Fatalf("Expected msgs of %d, got %d\n", total, m)
 	}
-	if b != total64*mlen {
-		t.Fatalf("Expected bytes of %d, got %d\n", total64*mlen, b)
+	if b != total*mlen {
+		t.Fatalf("Expected bytes of %d, got %d\n", total*mlen, b)
 	}
 
 	// Now drain some down and make sure pending is correct


### PR DESCRIPTION
This PR removes channels for async subscribers, #115 , cleans up #104 by adding  ChanSubscribe(), and addresses #86. Also cleans up handling of SlowConsumers.