### PR TITLE
Fix parser to check for missing sid.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -342,6 +342,9 @@ func (nc *Conn) processMsgArgs(arg []byte) error {
 	default:
 		return fmt.Errorf("nats: processMsgArgs Parse Error: '%s'", arg)
 	}
+	if nc.ps.ma.sid < 0 {
+		return fmt.Errorf("nats: processMsgArgs Bad or Missing Sid: '%s'", arg)
+	}
 	if nc.ps.ma.size < 0 {
 		return fmt.Errorf("nats: processMsgArgs Bad or Missing Size: '%s'", arg)
 	}


### PR DESCRIPTION
Adding tests for code coverage, I discovered that we would not check for missing sid (sid would be -1 due to parseInt64). I believe sid is mandatory.