### PR TITLE
Fix "Stale Connection" error check.

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -44,7 +44,7 @@ const (
 )
 
 // STALE_CONNECTION is for detection and proper handling of stale connections.
-const STALE_CONNECTION = "Stale Connection"
+const STALE_CONNECTION = "stale connection"
 
 // Errors
 var (
@@ -1489,7 +1489,7 @@ func (nc *Conn) LastError() error {
 // sets the connection's lastError.
 func (nc *Conn) processErr(e string) {
 	// FIXME(dlc) - process Slow Consumer signals special.
-	if e == STALE_CONNECTION {
+	if strings.ToLower(e) == STALE_CONNECTION {
 		nc.processOpErr(ErrStaleConnection)
 	} else {
 		nc.mu.Lock()

--- a/nats.go
+++ b/nats.go
@@ -44,7 +44,7 @@ const (
 )
 
 // STALE_CONNECTION is for detection and proper handling of stale connections.
-const STALE_CONNECTION = "stale connection"
+const STALE_CONNECTION = "Stale Connection"
 
 // Errors
 var (

--- a/nats_test.go
+++ b/nats_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -391,8 +392,10 @@ func TestParserErr(t *testing.T) {
 	if c.ps.argBuf == nil {
 		t.Fatal("ArgBuf should not be nil")
 	}
-	if string(c.ps.argBuf) != STALE_CONNECTION {
-		t.Fatalf("Wrong error, got '%v' expected '%v'", string(c.ps.argBuf), STALE_CONNECTION)
+	// processErr converts incoming error to lower case to do the check
+	lowerCaseErr := strings.ToLower(string(c.ps.argBuf))
+	if lowerCaseErr != STALE_CONNECTION {
+		t.Fatalf("Wrong error, got '%v' expected '%v'", lowerCaseErr, STALE_CONNECTION)
 	}
 
 	err = c.parse(errProto[len(errProto)-2:])

--- a/nats_test.go
+++ b/nats_test.go
@@ -404,17 +404,7 @@ func TestParserErr(t *testing.T) {
 	// See comment about server's error
 	// errProto = []byte("-ERR " + server.ErrStaleConnection.Error() + "\r\n")
 	errProto = []byte("-ERR Stale Connection\r\n")
-	err = c.parse(errProto[:len(errProto)-2])
-	if err != nil || c.ps.state != MINUS_ERR_ARG {
-		t.Fatalf("Unexpected: %d : %v\n", c.ps.state, err)
-	}
-	if c.ps.argBuf == nil {
-		t.Fatal("ArgBuf should not be nil")
-	}
-	if string(c.ps.argBuf) != STALE_CONNECTION {
-		t.Fatalf("Wrong error, got '%v' expected '%v'", string(c.ps.argBuf), STALE_CONNECTION)
-	}
-	err = c.parse(errProto[len(errProto)-2:])
+	err = c.parse(errProto)
 	if err != nil || c.ps.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.ps.state, err)
 	}


### PR DESCRIPTION
The case of the error message was changed to all lower case in the client. The server is using mixed case. This would cause the check to fail, resulting in connection close, instead of possibly trying to reconnect.