### PR TITLE
Fix nc.Flush() on connection close + much more code coverage.

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -538,6 +538,8 @@ const (
 	okProto    = _OK_OP_ + _CRLF_
 )
 
+/*
+// Commenting this out since it is not used for now and reduce test coverage
 func (nc *Conn) debugPool(str string) {
 	_, cur := nc.currentServer()
 	fmt.Printf("%s\n", str)
@@ -549,6 +551,7 @@ func (nc *Conn) debugPool(str string) {
 		}
 	}
 }
+*/
 
 // Return the currently selected server
 func (nc *Conn) currentServer() (int, *srv) {
@@ -2198,7 +2201,7 @@ func (nc *Conn) clearPendingFlushCalls() {
 	// Clear any queued pongs, e.g. pending flush calls.
 	for _, ch := range nc.pongs {
 		if ch != nil {
-			ch <- true
+			close(ch)
 		}
 	}
 	nc.pongs = nil

--- a/nats.go
+++ b/nats.go
@@ -538,21 +538,6 @@ const (
 	okProto    = _OK_OP_ + _CRLF_
 )
 
-/*
-// Commenting this out since it is not used for now and reduce test coverage
-func (nc *Conn) debugPool(str string) {
-	_, cur := nc.currentServer()
-	fmt.Printf("%s\n", str)
-	for i, s := range nc.srvPool {
-		if s == cur {
-			fmt.Printf("\t*%d: %v\n", i+1, s.url)
-		} else {
-			fmt.Printf("\t%d: %v\n", i+1, s.url)
-		}
-	}
-}
-*/
-
 // Return the currently selected server
 func (nc *Conn) currentServer() (int, *srv) {
 	for i, s := range nc.srvPool {

--- a/nats_test.go
+++ b/nats_test.go
@@ -411,6 +411,20 @@ func TestParserErr(t *testing.T) {
 	if err != nil || c.ps.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.ps.state, err)
 	}
+
+	// Other types of errors should close the connection and set LastError() to
+	// that error.
+	expectedError := "Any other error"
+	errProto = []byte("-ERR " + expectedError + "\r\n")
+	err = c.parse(errProto)
+	if err != nil || c.ps.state != OP_START {
+		t.Fatalf("Unexpected: %d : %v\n", c.ps.state, err)
+	}
+	// LastError() contains: 'nats: <error>', so check that expectedError is contained
+	// in LastError().
+	if !strings.Contains(c.LastError().Error(), expectedError) {
+		t.Fatalf("Unexpected error: '%v' instead of '%v'", c.LastError().Error(), expectedError)
+	}
 }
 
 func TestParserOK(t *testing.T) {

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -121,6 +121,40 @@ func TestSimplePublishNoData(t *testing.T) {
 	}
 }
 
+func TestPublishFailOnSlowConsumer(t *testing.T) {
+	// This whole test should be removed when/if we decide to fix the fact
+	// that the publish should not fail because of an async error.
+
+	s := RunDefaultServer()
+	defer s.Shutdown()
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	sub, err := nc.SubscribeSync("foo")
+	if err != nil {
+		t.Fatalf("Unable to create subscription: %v", err)
+	}
+
+	if err := sub.SetPendingLimits(1, 1000); err != nil {
+		t.Fatalf("Unable to set pending limits: %v", err)
+	}
+
+	var pubErr error
+
+	msg := []byte("Hello")
+	for i := 0; i < 10; i++ {
+		pubErr = nc.Publish("foo", msg)
+		if pubErr != nil {
+			break
+		}
+		nc.Flush()
+	}
+
+	if pubErr == nil || pubErr != nats.ErrSlowConsumer {
+		t.Fatalf("Expected '%v', got '%v'", nats.ErrSlowConsumer, pubErr)
+	}
+}
+
 func TestAsyncSubscribe(t *testing.T) {
 	s := RunDefaultServer()
 	defer s.Shutdown()
@@ -129,6 +163,11 @@ func TestAsyncSubscribe(t *testing.T) {
 
 	omsg := []byte("Hello World")
 	ch := make(chan bool)
+
+	// Callback is mandatory
+	if _, err := nc.Subscribe("foo", nil); err == nil {
+		t.Fatal("Creating subscription without callback should have failed")
+	}
 
 	_, err := nc.Subscribe("foo", func(m *nats.Msg) {
 		if !bytes.Equal(m.Data, omsg) {
@@ -194,11 +233,19 @@ func TestFlush(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		nc.Publish("flush", omsg)
 	}
+	if err := nc.FlushTimeout(0); err == nil {
+		t.Fatal("Calling FlushTimeout() with invalid timeout should fail")
+	}
 	if err := nc.Flush(); err != nil {
 		t.Fatalf("Received error from flush: %s\n", err)
 	}
 	if nb, _ := nc.Buffered(); nb > 0 {
 		t.Fatalf("Outbound buffer not empty: %d bytes\n", nb)
+	}
+
+	nc.Close()
+	if _, err := nc.Buffered(); err == nil {
+		t.Fatal("Calling Buffered() on closed connection should fail")
 	}
 }
 
@@ -490,5 +537,59 @@ func TestBadSubject(t *testing.T) {
 	}
 	if err != nats.ErrBadSubject {
 		t.Fatalf("Expected a ErrBadSubject error: Got %v\n", err)
+	}
+}
+
+func TestOptions(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc, err := nats.Connect(nats.DefaultURL, nats.Name("myName"), nats.MaxReconnects(2), nats.ReconnectWait(50*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer nc.Close()
+
+	rch := make(chan bool)
+	cch := make(chan bool)
+
+	nc.SetReconnectHandler(func(_ *nats.Conn) { rch <- true })
+	nc.SetClosedHandler(func(_ *nats.Conn) { cch <- true })
+
+	s.Shutdown()
+
+	s = RunDefaultServer()
+	defer s.Shutdown()
+
+	if err := Wait(rch); err != nil {
+		t.Fatal("Failed getting reconnected cb")
+	}
+
+	nc.Close()
+
+	if err := Wait(cch); err != nil {
+		t.Fatal("Failed getting closed cb")
+	}
+
+	nc, err = nats.Connect(nats.DefaultURL, nats.NoReconnect())
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer nc.Close()
+
+	nc.SetReconnectHandler(func(_ *nats.Conn) { rch <- true })
+	nc.SetClosedHandler(func(_ *nats.Conn) { cch <- true })
+
+	s.Shutdown()
+
+	// We should not get a reconnect cb this time
+	if err := WaitTime(rch, time.Second); err == nil {
+		t.Fatal("Unexpected reconnect cb")
+	}
+
+	nc.Close()
+
+	if err := Wait(cch); err != nil {
+		t.Fatal("Failed getting closed cb")
 	}
 }

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -122,8 +122,8 @@ func TestSimplePublishNoData(t *testing.T) {
 }
 
 func TestPublishFailOnSlowConsumer(t *testing.T) {
-	// This whole test should be removed when/if we decide to fix the fact
-	// that the publish should not fail because of an async error.
+	// FIXME(dlc): Remove this test when preventing failure to Publish()
+	// because of async error.
 
 	s := RunDefaultServer()
 	defer s.Shutdown()


### PR DESCRIPTION
- If nc.Flush[Timeout]() was waiting for a response and the connection would close, nc.Flush() would return without error. This is not appropriate. It will now return ErrConnectionClosed.
- Adding/Updating several tests for more code coverage.