### PR TITLE
Protobuf encoder improvement

### DIFF
--- a/encoders/protobuf/protobuf_enc.go
+++ b/encoders/protobuf/protobuf_enc.go
@@ -33,6 +33,9 @@ var (
 
 // Encode
 func (pb *ProtobufEncoder) Encode(subject string, v interface{}) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
 	i, found := v.(proto.Message)
 	if !found {
 		return nil, ErrInvalidProtoMsgEncode
@@ -47,6 +50,9 @@ func (pb *ProtobufEncoder) Encode(subject string, v interface{}) ([]byte, error)
 
 // Decode
 func (pb *ProtobufEncoder) Decode(subject string, data []byte, vPtr interface{}) error {
+	if _, ok := vPtr.(*interface{}); ok {
+		return nil
+	}
 	i, found := vPtr.(proto.Message)
 	if !found {
 		return ErrInvalidProtoMsgDecode


### PR DESCRIPTION
Hi

I found it convenient and intuitive to subscribe with empty interface{} in case when you don't need arguments to reply with encoded response. Also it's convenient to request with nil argument.

I used this modified proto encoder for our application.
I create failed test cases in commit: https://github.com/AnatoliiPrylutskyi/nats/commit/a3c60694003763933585705ca6f89b18599a8367

Thanks