### PR TITLE
Fixed reconnect loop possibly not yielding to Close()

### DIFF
--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"math"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -219,7 +220,7 @@ func TestHotSpotReconnect(t *testing.T) {
 	defer s1.Shutdown()
 
 	var srvrs string
-	if isWindows {
+	if runtime.GOOS == "windows" {
 		srvrs = strings.Join(testServers[:5], ",")
 	} else {
 		srvrs = servers
@@ -335,7 +336,7 @@ func TestProperFalloutAfterMaxAttempts(t *testing.T) {
 
 	opts := nats.DefaultOptions
 	// Reduce the list of servers for Windows tests
-	if isWindows {
+	if runtime.GOOS == "windows" {
 		opts.Servers = testServers[:2]
 		opts.MaxReconnect = 2
 	} else {
@@ -407,7 +408,7 @@ func TestProperFalloutAfterMaxAttemptsWithAuthMismatch(t *testing.T) {
 	opts := nats.DefaultOptions
 	opts.Servers = myServers
 	opts.NoRandomize = true
-	if isWindows {
+	if runtime.GOOS == "windows" {
 		opts.MaxReconnect = 2
 	} else {
 		opts.MaxReconnect = 5
@@ -472,7 +473,7 @@ func TestTimeoutOnNoServers(t *testing.T) {
 	defer s1.Shutdown()
 
 	opts := nats.DefaultOptions
-	if isWindows {
+	if runtime.GOOS == "windows" {
 		opts.Servers = testServers[:2]
 		opts.MaxReconnect = 2
 		opts.ReconnectWait = (100 * time.Millisecond)
@@ -521,7 +522,7 @@ func TestTimeoutOnNoServers(t *testing.T) {
 		t.Fatal("Did not receive a closed callback message")
 	}
 
-	if !isWindows {
+	if runtime.GOOS != "windows" {
 		timeWait := time.Since(startWait)
 
 		// Use 500ms as variable time delta

--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -100,6 +100,44 @@ var reconnectOpts = nats.Options{
 	Timeout:        nats.DefaultTimeout,
 }
 
+func TestConnCloseBreaksReconnectLoop(t *testing.T) {
+	ts := startReconnectServer(t)
+	defer ts.Shutdown()
+
+	cch := make(chan bool)
+
+	opts := reconnectOpts
+	// Bump the max reconnect attempts
+	opts.MaxReconnect = 100
+	opts.ClosedCB = func(_ *nats.Conn) {
+		cch <- true
+	}
+	nc, err := opts.Connect()
+	if err != nil {
+		t.Fatalf("Should have connected ok: %v", err)
+	}
+	defer nc.Close()
+	nc.Flush()
+
+	// Shutdown the server
+	ts.Shutdown()
+
+	// Wait a second, then close the connection
+	time.Sleep(time.Second)
+
+	// Close the connection, this should break the reconnect loop.
+	// Do this in a go routine since the issue was that Close()
+	// would block until the reconnect loop is done.
+	go nc.Close()
+
+	// Even on Windows (where a createConn takes more than a second)
+	// we should be able to break the reconnect loop with the following
+	// timeout.
+	if err := WaitTime(cch, 3*time.Second); err != nil {
+		t.Fatal("Did not get a closed callback")
+	}
+}
+
 func TestBasicReconnectFunctionality(t *testing.T) {
 	ts := startReconnectServer(t)
 	defer ts.Shutdown()

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -355,13 +355,8 @@ func TestCloseSubRelease(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 
-	// On Windows, the minimum waitTime is at least 15ms. So have a special check
-	// for this platform.
-	limit := 10
-	if isWindows {
-		limit = 20
-	}
-	if elapsed > time.Duration(limit)*time.Millisecond {
+	// On Windows, the minimum waitTime is at least 15ms.
+	if elapsed > 20*time.Millisecond {
 		t.Fatalf("Too much time has elapsed to release NextMsg: %dms",
 			(elapsed / time.Millisecond))
 	}

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -354,7 +354,14 @@ func TestCloseSubRelease(t *testing.T) {
 		t.Fatalf("Expected an error from NextMsg")
 	}
 	elapsed := time.Since(start)
-	if elapsed > 10*time.Millisecond {
+
+	// On Windows, the minimum waitTime is at least 15ms. So have a special check
+	// for this platform.
+	limit := 10
+	if isWindows {
+		limit = 20
+	}
+	if elapsed > time.Duration(limit)*time.Millisecond {
 		t.Fatalf("Too much time has elapsed to release NextMsg: %dms",
 			(elapsed / time.Millisecond))
 	}

--- a/test/test.go
+++ b/test/test.go
@@ -5,6 +5,7 @@ package test
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"time"
 
 	"github.com/nats-io/gnatsd/server"
@@ -12,6 +13,12 @@ import (
 
 	gnatsd "github.com/nats-io/gnatsd/test"
 )
+
+var isWindows bool
+
+func init() {
+	isWindows = (runtime.GOOS == "windows")
+}
 
 // So that we can pass tests and benchmarks...
 type tLogger interface {

--- a/test/test.go
+++ b/test/test.go
@@ -5,7 +5,6 @@ package test
 import (
 	"errors"
 	"fmt"
-	"runtime"
 	"time"
 
 	"github.com/nats-io/gnatsd/server"
@@ -13,12 +12,6 @@ import (
 
 	gnatsd "github.com/nats-io/gnatsd/test"
 )
-
-var isWindows bool
-
-func init() {
-	isWindows = (runtime.GOOS == "windows")
-}
 
 // So that we can pass tests and benchmarks...
 type tLogger interface {


### PR DESCRIPTION
The issue manifests on Windows with a ReconnectWait lower than a second, because it takes more than a second for createConn() to return when no server is running. Therefore, the loop would never sleep (and never release the lock), which would prevent a Close() from breaking the reconnect loop.