### PR TITLE
Fixed async callback dispatcher leak on connect failure

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -516,12 +516,14 @@ func (o Options) Connect() (*Conn, error) {
 
 	// Create the async callback channel.
 	nc.ach = make(chan asyncCB, asyncCBChanSize)
-	// Spin up the async cb dispatcher.
-	go nc.asyncDispatch()
 
 	if err := nc.connect(); err != nil {
 		return nil, err
 	}
+
+	// Spin up the async cb dispatcher on success
+	go nc.asyncDispatch()
+
 	return nc, nil
 }
 


### PR DESCRIPTION
-The dispatcher was started as a go routine before initiating the
 connect. However, if we failed to connect, we would never return
 a connection, so we would not shutdown this dispatcher since this
 was done in Close().
-Added a test which check go routines number before/after a failed
 connect.