### PR TITLE
Fixed leak of async subscription delivery routine on connection close

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -2332,6 +2332,10 @@ func (nc *Conn) close(status Status, doCBs bool) {
 		s.closed = true
 		// Mark connection closed in subscription
 		s.connClosed = true
+		// If we have an async subscription, signals it to exit
+		if s.typ == AsyncSubscription && s.pCond != nil {
+			s.pCond.Signal()
+		}
 
 		s.mu.Unlock()
 	}


### PR DESCRIPTION
-The async delivery routine was not signaled on connection close.
-Added tests that verify on unsubscribe and connection close.