### PR TITLE
Reconnect upon receiving an authorization timeout error

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -42,8 +42,11 @@ const (
 	LangString              = "go"
 )
 
-// STALE_CONNECTION is for detection and proper handling of stale connections.
-const STALE_CONNECTION = "stale connection"
+// errors values for detection and proper handling of out of band errors.
+const (
+	STALE_CONNECTION = "stale connection"
+	AUTH_TIMEOUT     = "authorization timeout"
+)
 
 // Errors
 var (
@@ -70,6 +73,7 @@ var (
 	ErrInvalidMsg           = errors.New("nats: invalid message or message nil")
 	ErrInvalidArg           = errors.New("nats: invalid argument")
 	ErrStaleConnection      = errors.New("nats: " + STALE_CONNECTION)
+	ErrAuthorizationTimeout = errors.New("nats: " + AUTH_TIMEOUT)
 )
 
 var DefaultOptions = Options{
@@ -1558,6 +1562,8 @@ func (nc *Conn) processErr(e string) {
 	// FIXME(dlc) - process Slow Consumer signals special.
 	if e == STALE_CONNECTION {
 		nc.processOpErr(ErrStaleConnection)
+	} else if e == AUTH_TIMEOUT {
+		nc.processOpErr(ErrAuthorizationTimeout)
 	} else {
 		nc.mu.Lock()
 		nc.err = errors.New("nats: " + e)

--- a/nats.go
+++ b/nats.go
@@ -42,7 +42,7 @@ const (
 	LangString              = "go"
 )
 
-// errors values for detection and proper handling of out of band errors.
+// Error values for detection and proper handling of out of band errors.
 const (
 	STALE_CONNECTION = "stale connection"
 	AUTH_TIMEOUT     = "authorization timeout"

--- a/nats_test.go
+++ b/nats_test.go
@@ -785,28 +785,3 @@ func TestNormalizeError(t *testing.T) {
 		t.Fatalf("Expected '%s', got '%s'", expected, s)
 	}
 }
-
-func TestAuthTimeoutWithDelayedDisconnect(t *testing.T) {
-	ts := RunServerOnPort(TEST_PORT)
-	defer ts.Shutdown()
-
-	reconnected := false
-	rch := make(chan bool)
-
-	opts := reconnectOpts
-	opts.ReconnectedCB = func(nc *Conn) {
-		reconnected = true
-		rch <- true
-	}
-	nc, _ := opts.Connect()
-	defer nc.Close()
-
-	// inject an authorization timeout into the connection, which should
-	// trigger a reconnect.
-	nc.processErr("Authorization Timeout")
-	Wait(rch)
-
-	if reconnected == false {
-		t.Fatalf("Did not reconnect after authorization timeout")
-	}
-}

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1005,7 +1005,7 @@ func TestErrInReadLoop(t *testing.T) {
 	close(done)
 }
 
-func TestErrStaleConnection(t *testing.T) {
+func testReconnectOnServerError(t *testing.T, serverErr string) {
 	serverInfo := "INFO {\"server_id\":\"foobar\",\"version\":\"0.7.3\",\"go\":\"go1.5.1\",\"host\":\"%s\",\"port\":%d,\"auth_required\":false,\"ssl_required\":false,\"max_payload\":1048576}\r\n"
 
 	l, e := net.Listen("tcp", "127.0.0.1:0")
@@ -1047,7 +1047,7 @@ func TestErrStaleConnection(t *testing.T) {
 			if i == 0 {
 				// Wait a tiny, and simulate a Stale Connection
 				time.Sleep(50 * time.Millisecond)
-				conn.Write([]byte("-ERR 'Stale Connection'\r\n"))
+				conn.Write([]byte(serverErr))
 
 				// The client should try to reconnect. When getting the
 				// disconnected callback, it will close this channel.
@@ -1107,6 +1107,14 @@ func TestErrStaleConnection(t *testing.T) {
 	}
 
 	close(done)
+}
+
+func TestErrStaleConnection(t *testing.T) {
+	testReconnectOnServerError(t, "-ERR 'Stale Connection'\r\n")
+}
+
+func TestErrAuthorizationTimeout(t *testing.T) {
+	testReconnectOnServerError(t, "-ERR 'Authorization Timeout'\r\n")
 }
 
 func TestServerErrorClosesConnection(t *testing.T) {


### PR DESCRIPTION
Begin the reconnect process upon receiving an authorization timeout error from the server.

In situations where a server is under high load, there can be a delay between the authorization timeout message being processed in the client and the connection being closed by the server.  Normally, the connection was being closed quickly, triggering the reconnect process.  However, if the authorization timeout was processed first, the client closed it's connection and did not reconnect when configured to.