### PR TITLE
Fix use of default connect timeout in opts.Connect()

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -510,6 +510,10 @@ func (o Options) Connect() (*Conn, error) {
 	if nc.Opts.ReconnectBufSize == 0 {
 		nc.Opts.ReconnectBufSize = DefaultReconnectBufSize
 	}
+	// Ensure that Timeout is not 0
+	if nc.Opts.Timeout == 0 {
+		nc.Opts.Timeout = DefaultTimeout
+	}
 
 	if err := nc.setupServerPool(); err != nil {
 		return nil, err

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1199,3 +1199,20 @@ func TestServerErrorClosesConnection(t *testing.T) {
 
 	close(done)
 }
+
+func TestUseDefaultTimeout(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	opts := &nats.Options{
+		Servers: []string{nats.DefaultURL},
+	}
+	nc, err := opts.Connect()
+	if err != nil {
+		t.Fatalf("Unexpected error on connect: %v", err)
+	}
+	defer nc.Close()
+	if nc.Opts.Timeout != nats.DefaultTimeout {
+		t.Fatalf("Expected Timeout to be set to %v, got %v", nats.DefaultTimeout, nc.Opts.Timeout)
+	}
+}


### PR DESCRIPTION
If one creates a nats.Options struct and does not specify a timeout,
the library would use 0 for the connect timeout which would prevent
the connect to succeed. If timeout is not specify, the default
value (2 seconds) will now be used.