### PR TITLE
Update nats bench

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Test Lib",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "remotePath": "",
+            "port": 2345,
+            "host": "127.0.0.1",
+            "program": "${workspaceRoot}/bench",
+            "env": {},
+            "args": ["-test.v", "-test.run", "TestBenchStrings"]            
+        },
+        {
+            "name": "Launch",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "remotePath": "",
+            "port": 2345,
+            "host": "127.0.0.1",
+            "program": "${workspaceRoot}",
+            "env": {},
+            "args": []
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+}

--- a/bench/bench.go
+++ b/bench/bench.go
@@ -1,0 +1,335 @@
+// Copyright 2012-2016 Apcera Inc. All rights reserved.
+
+package bench
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"log"
+	"math"
+	"strconv"
+	"time"
+
+	"github.com/nats-io/nats"
+	"github.com/nats-io/nuid"
+)
+
+// A Sample for a particular client
+type Sample struct {
+	JobMsgCnt int
+	MsgCnt    uint64
+	MsgBytes  uint64
+	IOBytes   uint64
+	Start     time.Time
+	End       time.Time
+}
+
+// SampleGroup for a number of samples, the group is a Sample itself agregating the values the Samples
+type SampleGroup struct {
+	Sample
+	Samples []*Sample
+}
+
+// Benchmark to hold the various Samples organized by publishers and subscribers
+type Benchmark struct {
+	Sample
+	RunID      string
+	Pubs       *SampleGroup
+	Subs       *SampleGroup
+	subChannel chan *Sample
+	pubChannel chan *Sample
+}
+
+// NewBenchmark initializes a Benchmark. After creating a bench call AddSubSample/AddPubSample.
+// When done collecting samples, call EndBenchmark
+func NewBenchmark(subCnt, pubCnt int) *Benchmark {
+	bm := Benchmark{RunID: nuid.Next()}
+	bm.Subs = NewSampleGroup()
+	bm.Pubs = NewSampleGroup()
+	if subCnt > 0 {
+		bm.subChannel = make(chan *Sample, subCnt)
+	}
+	if pubCnt > 0 {
+		bm.pubChannel = make(chan *Sample, pubCnt)
+	}
+	return &bm
+}
+
+// Close organizes collected Samples and calculates aggregates. After Close(), no more samples can be added.
+func (bm *Benchmark) Close() {
+	close(bm.subChannel)
+	close(bm.pubChannel)
+
+	for s := range bm.subChannel {
+		bm.Subs.AddSample(s)
+	}
+	for s := range bm.pubChannel {
+		bm.Pubs.AddSample(s)
+	}
+
+	bm.Start = bm.Subs.Start
+	if bm.Start.After(bm.Pubs.Start) {
+		bm.Start = bm.Pubs.Start
+	}
+	bm.End = bm.Subs.End
+	if bm.End.Before(bm.Pubs.End) {
+		bm.End = bm.Pubs.End
+	}
+
+	bm.MsgBytes = bm.Pubs.MsgBytes + bm.Subs.MsgBytes
+	bm.IOBytes = bm.Pubs.IOBytes + bm.Subs.IOBytes
+	bm.MsgCnt = bm.Pubs.MsgCnt + bm.Subs.MsgCnt
+	bm.JobMsgCnt = bm.Pubs.JobMsgCnt + bm.Subs.JobMsgCnt
+}
+
+// AddSubSample to the benchmark
+func (bm *Benchmark) AddSubSample(s *Sample) {
+	bm.subChannel <- s
+}
+
+// AddPubSample to the benchmark
+func (bm *Benchmark) AddPubSample(s *Sample) {
+	bm.pubChannel <- s
+}
+
+// CSV generates a csv report of all the samples collected
+func (bm *Benchmark) CSV() string {
+	var buffer bytes.Buffer
+	writer := csv.NewWriter(&buffer)
+	writer.Write([]string{"#RunID", "ClientID", "MsgCount", "MsgBytes", "MsgsPerSec", "BytesPerSec", "DurationSecs"})
+	groups := []*SampleGroup{bm.Subs, bm.Pubs}
+	pre := "S"
+	for i, g := range groups {
+		if i == 1 {
+			pre = "P"
+		}
+		for j, c := range g.Samples {
+			r := []string{bm.RunID, fmt.Sprintf("%s%d", pre, j), fmt.Sprintf("%d", c.MsgCnt), fmt.Sprintf("%d", c.MsgBytes), fmt.Sprintf("%d", c.Rate()), fmt.Sprintf("%f", c.Throughput()), fmt.Sprintf("%f", c.Duration().Seconds())}
+			err := writer.Write(r)
+			if err != nil {
+				log.Fatalf("Error while serializing %v: %v", c, err)
+			}
+		}
+	}
+
+	writer.Flush()
+	return buffer.String()
+}
+
+// NewSample creates a new Sample initialized to the provided values. The nats.Conn information captured
+func NewSample(jobCount int, msgSize int, start, end time.Time, nc *nats.Conn) *Sample {
+	s := Sample{JobMsgCnt: jobCount, Start: start, End: end}
+	s.MsgBytes = uint64(msgSize * jobCount)
+	s.MsgCnt = nc.OutMsgs + nc.InMsgs
+	s.IOBytes = nc.OutBytes + nc.InBytes
+	return &s
+}
+
+// Throughput of bytes per second
+func (s *Sample) Throughput() float64 {
+	return float64(s.MsgBytes) / s.Duration().Seconds()
+}
+
+// Rate of meessages in the job per second
+func (s *Sample) Rate() int64 {
+	return int64(float64(s.JobMsgCnt) / s.Duration().Seconds())
+}
+
+func (s *Sample) String() string {
+	rate := commaFormat(s.Rate())
+	jobMessages := commaFormat(int64(s.JobMsgCnt))
+	protocolMessages := commaFormat(int64(s.MsgCnt - uint64(s.JobMsgCnt)))
+	throughput := humanBytes(s.Throughput(), false)
+	return fmt.Sprintf("%s msgs/sec | %s (%s pmsgs) msgs in %v | %s/sec", rate, jobMessages, protocolMessages, s.Duration(), throughput)
+}
+
+// Duration that the sample was active
+func (s *Sample) Duration() time.Duration {
+	return s.End.Sub(s.Start)
+}
+
+// Seconds that the sample or samples were active
+func (s *Sample) Seconds() float64 {
+	return s.Duration().Seconds()
+}
+
+// NewSampleGroup initializer
+func NewSampleGroup() *SampleGroup {
+	s := new(SampleGroup)
+	s.Samples = make([]*Sample, 0, 0)
+	return s
+}
+
+// Statistics information of the sample group (min, average, max and standard deviation)
+func (sg *SampleGroup) Statistics() string {
+	return fmt.Sprintf("min %s | avg %s | max %s | stddev %s msgs", commaFormat(sg.MinRate()), commaFormat(sg.AvgRate()), commaFormat(sg.MaxRate()), commaFormat(int64(sg.StdDev())))
+}
+
+// MinRate returns the smallest message rate in the SampleGroup
+func (sg *SampleGroup) MinRate() int64 {
+	m := int64(0)
+	for i, s := range sg.Samples {
+		if i == 0 {
+			m = s.Rate()
+		}
+		m = min(m, s.Rate())
+	}
+	return m
+}
+
+// MaxRate returns the largest message rate in the SampleGroup
+func (sg *SampleGroup) MaxRate() int64 {
+	m := int64(0)
+	for i, s := range sg.Samples {
+		if i == 0 {
+			m = s.Rate()
+		}
+		m = max(m, s.Rate())
+	}
+	return m
+}
+
+// AvgRate returns the average of all the message rates in the SampleGroup
+func (sg *SampleGroup) AvgRate() int64 {
+	sum := uint64(0)
+	for _, s := range sg.Samples {
+		sum += uint64(s.Rate())
+	}
+	return int64(sum / uint64(len(sg.Samples)))
+}
+
+// StdDev returns the standard deviation the message rates in the SampleGroup
+func (sg *SampleGroup) StdDev() float64 {
+	avg := float64(sg.AvgRate())
+	sum := float64(0)
+	for _, c := range sg.Samples {
+		sum += math.Pow(float64(c.Rate())-avg, 2)
+	}
+	variance := sum / float64(len(sg.Samples))
+	return math.Sqrt(variance)
+}
+
+// AddSample adds a Sample to the SampleGroup. After adding a Sample it shouldn't be modified.
+func (sg *SampleGroup) AddSample(e *Sample) {
+	sg.Samples = append(sg.Samples, e)
+
+	if len(sg.Samples) == 1 {
+		sg.Start = e.Start
+		sg.End = e.End
+	}
+	sg.IOBytes += e.IOBytes
+	sg.JobMsgCnt += e.JobMsgCnt
+	sg.MsgCnt += e.MsgCnt
+	sg.MsgBytes += e.MsgBytes
+
+	if e.Start.Before(sg.Start) {
+		sg.Start = e.Start
+	}
+
+	if e.End.After(sg.End) {
+		sg.End = e.End
+	}
+}
+
+// String returns a human readable report of the samples taken in the Benchmark
+func (bm *Benchmark) String() string {
+	var buffer bytes.Buffer
+	jobCount := commaFormat(int64(bm.JobMsgCnt))
+	msgRate := commaFormat(bm.Rate())
+	buffer.WriteString(fmt.Sprintf("NATS (Publishers/Subscribers) throughput is %s msgs/sec (%s msgs in %v)\n", msgRate, jobCount, bm.Duration()))
+
+	overhead := bm.IOBytes - bm.MsgBytes
+	buffer.WriteString(fmt.Sprintf("Data/Overhead: %s / %s\n", humanBytes(float64(bm.MsgBytes), false), humanBytes(float64(overhead), false)))
+
+	pubCount := len(bm.Pubs.Samples)
+	if pubCount > 0 {
+		buffer.WriteString(fmt.Sprintf(" Publisher Stats (%d) %v\n", pubCount, bm.Pubs))
+		if pubCount > 1 {
+			for i, stat := range bm.Pubs.Samples {
+				buffer.WriteString(fmt.Sprintf("  [%d] %v\n", i+1, stat))
+			}
+			buffer.WriteString(fmt.Sprintf("  %s\n", bm.Pubs.Statistics()))
+		}
+	}
+
+	subCount := len(bm.Subs.Samples)
+	if subCount > 0 {
+		buffer.WriteString(fmt.Sprintf(" Subscriber Stats (%d) %v\n", subCount, bm.Subs))
+		if subCount > 1 {
+			for i, stat := range bm.Subs.Samples {
+				buffer.WriteString(fmt.Sprintf("  [%d] %v\n", i+1, stat))
+			}
+			buffer.WriteString(fmt.Sprintf("  %s\n", bm.Subs.Statistics()))
+		}
+	}
+	return buffer.String()
+}
+
+func commaFormat(n int64) string {
+	in := strconv.FormatInt(n, 10)
+	out := make([]byte, len(in)+(len(in)-2+int(in[0]/'0'))/3)
+	if in[0] == '-' {
+		in, out[0] = in[1:], '-'
+	}
+	for i, j, k := len(in)-1, len(out)-1, 0; ; i, j = i-1, j-1 {
+		out[j] = in[i]
+		if i == 0 {
+			return string(out)
+		}
+		if k++; k == 3 {
+			j, k = j-1, 0
+			out[j] = ','
+		}
+	}
+}
+
+func humanBytes(bytes float64, si bool) string {
+	var base = 1024
+	pre := []string{"K", "M", "G", "T", "P", "E"}
+	var post = "B"
+	if si {
+		base = 1000
+		pre = []string{"k", "M", "G", "T", "P", "E"}
+		post = "iB"
+	}
+	if bytes < float64(base) {
+		return fmt.Sprintf("%.2f B", bytes)
+	}
+	exp := int(math.Log(bytes) / math.Log(float64(base)))
+	index := exp - 1
+	units := pre[index] + post
+	return fmt.Sprintf("%.2f %s", bytes/math.Pow(float64(base), float64(exp)), units)
+}
+
+func min(x, y int64) int64 {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func max(x, y int64) int64 {
+	if x > y {
+		return x
+	}
+	return y
+}
+
+// MsgsPerClient divides the number of messages by the number of clients and tries to distribute them as evenly as possible
+func MsgsPerClient(numMsgs, numClients int) []int {
+	var counts []int
+	if numClients == 0 || numMsgs == 0 {
+		return counts
+	}
+	counts = make([]int, numClients)
+	mc := numMsgs / numClients
+	for i := 0; i < numClients; i++ {
+		counts[i] = mc
+	}
+	extra := numMsgs % numClients
+	for i := 0; i < extra; i++ {
+		counts[i]++
+	}
+	return counts
+}

--- a/bench/bench.go
+++ b/bench/bench.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 Apcera Inc. All rights reserved.
+// Copyright 2016 Apcera Inc. All rights reserved.
 
 package bench
 
@@ -97,7 +97,10 @@ func (bm *Benchmark) AddPubSample(s *Sample) {
 func (bm *Benchmark) CSV() string {
 	var buffer bytes.Buffer
 	writer := csv.NewWriter(&buffer)
-	writer.Write([]string{"#RunID", "ClientID", "MsgCount", "MsgBytes", "MsgsPerSec", "BytesPerSec", "DurationSecs"})
+	headers := []string{"#RunID", "ClientID", "MsgCount", "MsgBytes", "MsgsPerSec", "BytesPerSec", "DurationSecs"}
+	if err := writer.Write(headers); err != nil {
+		log.Fatal("Error while serializing headers %q: %v", headers, err)
+	}
 	groups := []*SampleGroup{bm.Subs, bm.Pubs}
 	pre := "S"
 	for i, g := range groups {
@@ -106,8 +109,7 @@ func (bm *Benchmark) CSV() string {
 		}
 		for j, c := range g.Samples {
 			r := []string{bm.RunID, fmt.Sprintf("%s%d", pre, j), fmt.Sprintf("%d", c.MsgCnt), fmt.Sprintf("%d", c.MsgBytes), fmt.Sprintf("%d", c.Rate()), fmt.Sprintf("%f", c.Throughput()), fmt.Sprintf("%f", c.Duration().Seconds())}
-			err := writer.Write(r)
-			if err != nil {
+			if err := writer.Write(r); err != nil {
 				log.Fatalf("Error while serializing %v: %v", c, err)
 			}
 		}

--- a/bench/benchlib_test.go
+++ b/bench/benchlib_test.go
@@ -1,0 +1,221 @@
+package bench
+
+import (
+	"github.com/nats-io/nats"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	Byte    = 8
+	Million = 1000 * 1000
+)
+
+var baseTime = time.Now()
+
+func millionMessagesSecondSample(seconds int) *Sample {
+	messages := Million * seconds
+	start := baseTime
+	end := start.Add(time.Second * time.Duration(seconds))
+	nc := new(nats.Conn)
+
+	s := NewSample(messages, Byte, start, end, nc)
+	s.MsgCnt = uint64(messages)
+	s.MsgBytes = uint64(messages * Byte)
+	s.IOBytes = s.MsgBytes
+	return s
+}
+
+func TestDuration(t *testing.T) {
+	s := millionMessagesSecondSample(1)
+	duration := s.End.Sub(s.Start)
+	if duration != s.Duration() || duration != time.Second {
+		t.Fail()
+	}
+}
+
+func TestSeconds(t *testing.T) {
+	s := millionMessagesSecondSample(1)
+	seconds := s.End.Sub(s.Start).Seconds()
+	if seconds != s.Seconds() || seconds != 1.0 {
+		t.Fail()
+	}
+}
+
+func TestRate(t *testing.T) {
+	s := millionMessagesSecondSample(60)
+	if s.Rate() != Million {
+		t.Fail()
+	}
+}
+
+func TestThoughput(t *testing.T) {
+	s := millionMessagesSecondSample(60)
+	if s.Throughput() != Million*Byte {
+		t.Fail()
+	}
+}
+
+func TestStrings(t *testing.T) {
+	s := millionMessagesSecondSample(60)
+	if len(s.String()) == 0 {
+		t.Fail()
+	}
+}
+
+func TestGroupDuration(t *testing.T) {
+	sg := NewSampleGroup()
+	sg.AddSample(millionMessagesSecondSample(1))
+	sg.AddSample(millionMessagesSecondSample(2))
+	duration := sg.End.Sub(sg.Start)
+	if duration != sg.Duration() || duration != time.Duration(2)*time.Second {
+		t.Fail()
+	}
+}
+
+func TestGroupSeconds(t *testing.T) {
+	sg := NewSampleGroup()
+	sg.AddSample(millionMessagesSecondSample(1))
+	sg.AddSample(millionMessagesSecondSample(2))
+	sg.AddSample(millionMessagesSecondSample(3))
+	seconds := sg.End.Sub(sg.Start).Seconds()
+	if seconds != sg.Seconds() || seconds != 3.0 {
+		t.Fail()
+	}
+}
+
+func TestGroupRate(t *testing.T) {
+	sg := NewSampleGroup()
+	sg.AddSample(millionMessagesSecondSample(1))
+	sg.AddSample(millionMessagesSecondSample(2))
+	sg.AddSample(millionMessagesSecondSample(3))
+	if sg.Rate() != Million*2 {
+		t.Fail()
+	}
+}
+
+func TestGroupThoughput(t *testing.T) {
+	sg := NewSampleGroup()
+	sg.AddSample(millionMessagesSecondSample(1))
+	sg.AddSample(millionMessagesSecondSample(2))
+	sg.AddSample(millionMessagesSecondSample(3))
+	if sg.Throughput() != 2*Million*Byte {
+		t.Fail()
+	}
+}
+
+func TestMinMaxRate(t *testing.T) {
+	sg := NewSampleGroup()
+	sg.AddSample(millionMessagesSecondSample(1))
+	sg.AddSample(millionMessagesSecondSample(2))
+	sg.AddSample(millionMessagesSecondSample(3))
+	if sg.MinRate() != sg.MaxRate() {
+		t.Fail()
+	}
+}
+
+func TestAvgRate(t *testing.T) {
+	sg := NewSampleGroup()
+	sg.AddSample(millionMessagesSecondSample(1))
+	sg.AddSample(millionMessagesSecondSample(2))
+	sg.AddSample(millionMessagesSecondSample(3))
+	if sg.MinRate() != sg.AvgRate() {
+		t.Fail()
+	}
+}
+
+func TestStdDev(t *testing.T) {
+	sg := NewSampleGroup()
+	sg.AddSample(millionMessagesSecondSample(1))
+	sg.AddSample(millionMessagesSecondSample(2))
+	sg.AddSample(millionMessagesSecondSample(3))
+	if sg.StdDev() != 0.0 {
+		t.Fail()
+	}
+}
+
+func TestBenchSetup(t *testing.T) {
+	bench := NewBenchmark(1, 1)
+	bench.AddSubSample(millionMessagesSecondSample(1))
+	bench.AddPubSample(millionMessagesSecondSample(1))
+	bench.Close()
+	if len(bench.RunID) == 0 {
+		t.Fail()
+	}
+	if len(bench.Pubs.Samples) != 1 || len(bench.Subs.Samples) != 1 {
+		t.Fail()
+	}
+
+	if bench.MsgCnt != 2*Million || bench.IOBytes != 2*Million*8 {
+		t.Fail()
+	}
+
+	if bench.Duration() != time.Second {
+		t.Fail()
+	}
+}
+
+func makeBench(subs, pubs int) *Benchmark {
+	bench := NewBenchmark(subs, pubs)
+	for i := 0; i < subs; i++ {
+		bench.AddSubSample(millionMessagesSecondSample(1))
+	}
+	for i := 0; i < pubs; i++ {
+		bench.AddPubSample(millionMessagesSecondSample(1))
+	}
+	bench.Close()
+	return bench
+}
+
+func TestCsv(t *testing.T) {
+	bench := makeBench(1, 1)
+	csv := bench.CSV()
+	lines := strings.Split(csv, "\n")
+	// there's a header line and trailing ""
+	if len(lines) != 4 {
+		t.Fail()
+	}
+
+	fields := strings.Split(lines[1], ",")
+	if len(fields) != 7 {
+		t.Fail()
+	}
+}
+
+func TestBenchStrings(t *testing.T) {
+	bench := makeBench(1, 1)
+	s := bench.String()
+	lines := strings.Split(s, "\n")
+	// header, overhead, pub header, sub headers, empty
+	if len(lines) != 5 {
+		t.Fail()
+	}
+
+	bench = makeBench(2, 2)
+	s = bench.String()
+	lines = strings.Split(s, "\n")
+	// header, overhead, pub header, pub x 2, stats, sub headers, sub x 2, stats, empty
+	if len(lines) != 11 {
+		t.Fail()
+	}
+}
+
+func TestMsgsPerClient(t *testing.T) {
+	zero := MsgsPerClient(0, 0)
+	if len(zero) != 0 {
+		t.Fail()
+	}
+	onetwo := MsgsPerClient(1, 2)
+	if len(onetwo) != 2 || onetwo[0] != 1 || onetwo[1] != 0 {
+		t.Fail()
+	}
+	twotwo := MsgsPerClient(2, 2)
+	if len(twotwo) != 2 || twotwo[0] != 1 || twotwo[1] != 1 {
+		t.Fail()
+	}
+	threetwo := MsgsPerClient(3, 2)
+	if len(threetwo) != 2 || threetwo[0] != 2 || threetwo[1] != 1 {
+		t.Fail()
+	}
+}

--- a/examples/nats-bench.go
+++ b/examples/nats-bench.go
@@ -3,21 +3,16 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
-	"math"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"encoding/csv"
-	"encoding/json"
-
 	"github.com/nats-io/nats"
+	"github.com/nats-io/nats/bench"
 )
 
 // Some sane defaults
@@ -29,11 +24,10 @@ const (
 )
 
 func usage() {
-	log.Fatalf("Usage: nats-bench [-s server (%s)] [--tls] [-np NUM_PUBLISHERS] [-ns NUM_SUBSCRIBERS] [-n NUM_MSGS] [-ms MESSAGE_SIZE] [-o jsonfile] [-csv csvfile] <subject>\n", nats.DefaultURL)
+	log.Fatalf("Usage: nats-bench [-s server (%s)] [--tls] [-np NUM_PUBLISHERS] [-ns NUM_SUBSCRIBERS] [-n NUM_MSGS] [-ms MESSAGE_SIZE] [-csv csvfile] <subject>\n", nats.DefaultURL)
 }
 
-var subStatChan chan *stats
-var pubStatChan chan *stats
+var benchmark *bench.Benchmark
 
 func main() {
 	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
@@ -43,7 +37,6 @@ func main() {
 	var numMsgs = flag.Int("n", DefaultNumMsgs, "Number of Messages to Publish")
 	var msgSize = flag.Int("ms", DefaultMessageSize, "Size of the message.")
 	var csvFile = flag.String("csv", "", "Save bench data to csv file")
-	var jsonFile = flag.String("o", "", "Save raw data to json file")
 
 	log.SetFlags(0)
 	flag.Usage = usage
@@ -62,8 +55,7 @@ func main() {
 	}
 	opts.Secure = *tls
 
-	subStatChan = make(chan *stats, *numSubs)
-	pubStatChan = make(chan *stats, *numPubs)
+	benchmark = bench.NewBenchmark(*numSubs, *numPubs)
 
 	var startwg sync.WaitGroup
 	var donewg sync.WaitGroup
@@ -72,7 +64,7 @@ func main() {
 
 	// Run Subscribers first
 	startwg.Add(*numSubs)
-	subCounts := msgsPerClient(*numMsgs, *numSubs)
+	subCounts := bench.MsgsPerClient(*numMsgs, *numSubs)
 	for i := 0; i < *numSubs; i++ {
 		go runSubscriber(&startwg, &donewg, opts, subCounts[i], *msgSize)
 	}
@@ -80,7 +72,7 @@ func main() {
 
 	// Now Publishers
 	startwg.Add(*numPubs)
-	pubCounts := msgsPerClient(*numMsgs, *numPubs)
+	pubCounts := bench.MsgsPerClient(*numMsgs, *numPubs)
 	for i := 0; i < *numPubs; i++ {
 		go runPublisher(&startwg, &donewg, opts, pubCounts[i], *msgSize)
 	}
@@ -88,33 +80,14 @@ func main() {
 	log.Printf("Starting benchmark [msgs=%d, pubs=%d, subs=%d]\n", *numMsgs, *numPubs, *numSubs)
 
 	startwg.Wait()
-	start := time.Now()
 	donewg.Wait()
-	end := time.Now()
 
-	close(pubStatChan)
-	pubStats := newStatSums()
-	for s := range pubStatChan {
-		pubStats.addStat(s)
-	}
+	benchmark.Close()
 
-	close(subStatChan)
-	subStats := newStatSums()
-	for s := range subStatChan {
-		subStats.addStat(s)
-	}
+	fmt.Print(benchmark)
 
-	bench := newBenchStats(start, end, pubStats, subStats)
-	fmt.Print(bench.human())
-
-	if "" != *jsonFile {
-		json := bench.json()
-		ioutil.WriteFile(*jsonFile, []byte(json), 0644)
-		fmt.Printf("Saved JSON data for the run in %s\n", *jsonFile)
-	}
-
-	if "" != *csvFile {
-		csv := bench.csv()
+	if len(*csvFile) > 0 {
+		csv := benchmark.CSV()
 		ioutil.WriteFile(*csvFile, []byte(csv), 0644)
 		fmt.Printf("Saved metric data in csv file %s\n", *csvFile)
 	}
@@ -140,7 +113,7 @@ func runPublisher(startwg, donewg *sync.WaitGroup, opts nats.Options, numMsgs in
 	for i := 0; i < numMsgs; i++ {
 		nc.Publish(subj, msg)
 	}
-	pubStatChan <- newStats(numMsgs, msgSize, start, time.Now(), nc, true)
+	benchmark.AddPubSample(bench.NewSample(numMsgs, msgSize, start, time.Now(), nc))
 
 	nc.Flush()
 	donewg.Done()
@@ -160,297 +133,11 @@ func runSubscriber(startwg, donewg *sync.WaitGroup, opts nats.Options, numMsgs i
 	nc.Subscribe(subj, func(msg *nats.Msg) {
 		received++
 		if received >= numMsgs {
-			subStatChan <- newStats(numMsgs, msgSize, start, time.Now(), nc, false)
+			benchmark.AddSubSample(bench.NewSample(numMsgs, msgSize, start, time.Now(), nc))
 			donewg.Done()
 			nc.Close()
 		}
 	})
 	nc.Flush()
 	startwg.Done()
-}
-
-type stats struct {
-	JobCount int
-	MsgBytes uint64
-	IOBytes  uint64
-	MsgCount uint64
-	Start    time.Time
-	End      time.Time
-}
-
-func newStats(jobCount int, msgSize int, start, end time.Time, nc *nats.Conn, isPub bool) *stats {
-	s := stats{JobCount: jobCount, Start: start, End: end}
-	s.MsgBytes = uint64(msgSize * jobCount)
-	if isPub {
-		s.MsgCount = nc.OutMsgs
-		s.IOBytes = nc.OutBytes
-	} else {
-		s.MsgCount = nc.InMsgs
-		s.IOBytes = nc.InBytes
-	}
-	return &s
-}
-
-func (s *stats) throughput() float64 {
-	return float64(s.MsgBytes) / s.duration().Seconds()
-}
-
-func (s *stats) rate() int64 {
-	return int64(float64(s.JobCount) / s.duration().Seconds())
-}
-
-func (s *stats) String() string {
-	rate := commaFormat(s.rate())
-	jobMessages := commaFormat(int64(s.JobCount))
-	protocolMessages := commaFormat(int64(s.MsgCount - uint64(s.JobCount)))
-	throughput := humanBytes(s.throughput(), false)
-	return fmt.Sprintf("%s msgs/sec | %s (%s pmsgs) msgs in %v | %s/sec", rate, jobMessages, protocolMessages, s.duration(), throughput)
-}
-
-func (s *stats) duration() time.Duration {
-	return s.End.Sub(s.Start)
-}
-
-func (s *stats) Seconds() float64 {
-	return s.duration().Seconds()
-}
-
-type statSums struct {
-	stats
-	Clients []*stats
-}
-
-func newStatSums() *statSums {
-	s := new(statSums)
-	s.Clients = make([]*stats, 0, 0)
-	return s
-}
-
-func (s *statSums) minMaxAverage() string {
-	return fmt.Sprintf("min %s | avg %s | max %s | stddev %s msgs", commaFormat(s.minRate()), commaFormat(s.avgRate()), commaFormat(s.maxRate()), commaFormat(int64(s.stddev())))
-}
-
-func (s *statSums) minRate() int64 {
-	m := int64(0)
-	for i, c := range s.Clients {
-		if i == 0 {
-			m = c.rate()
-		}
-		m = min(m, c.rate())
-	}
-	return m
-}
-
-func (s *statSums) maxRate() int64 {
-	m := int64(0)
-	for i, c := range s.Clients {
-		if i == 0 {
-			m = c.rate()
-		}
-		m = max(m, c.rate())
-	}
-	return m
-}
-
-func (s *statSums) avgRate() int64 {
-	sum := uint64(0)
-	for _, c := range s.Clients {
-		sum += uint64(c.rate())
-	}
-	return int64(sum / uint64(len(s.Clients)))
-}
-
-func (s *statSums) stddev() float64 {
-	avg := float64(s.avgRate())
-	sum := float64(0)
-	for _, c := range s.Clients {
-		sum += math.Pow(float64(c.rate())-avg, 2)
-	}
-	variance := sum / float64(len(s.Clients))
-	return math.Sqrt(variance)
-}
-
-func (s *statSums) addStat(e *stats) {
-	s.Clients = append(s.Clients, e)
-
-	if len(s.Clients) == 1 {
-		s.Start = e.Start
-		s.End = e.End
-	}
-	s.IOBytes += e.IOBytes
-	s.JobCount += e.JobCount
-	s.MsgCount += e.MsgCount
-	s.MsgBytes += e.MsgBytes
-
-	if e.Start.Before(s.Start) {
-		s.Start = e.Start
-	}
-
-	if e.End.After(s.End) {
-		s.End = e.End
-	}
-}
-
-type benchStats struct {
-	stats
-	PubStats *statSums
-	SubStats *statSums
-}
-
-func newBenchStats(start, end time.Time, pubStats, subStats *statSums) *benchStats {
-	bs := benchStats{PubStats: pubStats, SubStats: subStats}
-	bs.Start = start
-	bs.End = end
-	bs.MsgBytes = pubStats.MsgBytes + subStats.MsgBytes
-	bs.IOBytes = pubStats.IOBytes + subStats.IOBytes
-	bs.MsgCount = pubStats.MsgCount + subStats.MsgCount
-	bs.JobCount = pubStats.JobCount + subStats.JobCount
-	return &bs
-}
-
-func (b *benchStats) human() string {
-	var buffer bytes.Buffer
-	jobCount := commaFormat(int64(b.JobCount))
-	msgThroughput := commaFormat(b.rate())
-	buffer.WriteString(fmt.Sprintf("NATS (Publishers/Subscribers) throughput is %s msgs/sec (%s msgs in %v)\n", msgThroughput, jobCount, b.duration()))
-
-	overhead := b.IOBytes - b.MsgBytes
-	buffer.WriteString(fmt.Sprintf("Data/Overhead: %s / %s\n", humanBytes(float64(b.MsgBytes), false), humanBytes(float64(overhead), false)))
-
-	pubCount := len(b.PubStats.Clients)
-	if pubCount > 0 {
-		buffer.WriteString(fmt.Sprintf(" Publisher Stats (%d) %v\n", pubCount, b.PubStats))
-		if pubCount > 1 {
-			for i, stat := range b.PubStats.Clients {
-				buffer.WriteString(fmt.Sprintf("  [%d] %v\n", i+1, stat))
-			}
-			buffer.WriteString(fmt.Sprintf("  %s\n", b.PubStats.minMaxAverage()))
-		}
-	}
-
-	subCount := len(b.SubStats.Clients)
-	if subCount > 0 {
-		buffer.WriteString(fmt.Sprintf(" Subscriber Stats (%d) %v\n", subCount, b.SubStats))
-		if subCount > 1 {
-			for i, stat := range b.SubStats.Clients {
-				buffer.WriteString(fmt.Sprintf("  [%d] %v\n", i+1, stat))
-			}
-			buffer.WriteString(fmt.Sprintf("  %s\n", b.SubStats.minMaxAverage()))
-		}
-	}
-	return buffer.String()
-}
-
-func (b *benchStats) json() string {
-	var buffer bytes.Buffer
-	bytes, _ := json.Marshal(b)
-	json.Indent(&buffer, bytes, "", " ")
-	return buffer.String()
-}
-
-type results struct {
-	Desc         string
-	MsgCnt       int
-	MsgBytes     uint64
-	MsgsPerSec   int64
-	BytesPerSec  float64
-	DurationSecs float64
-}
-
-func (b *benchStats) results() []results {
-	pubs := len(b.PubStats.Clients)
-	subs := len(b.SubStats.Clients)
-	buf := make([]results, pubs+subs)
-	var s *stats
-	for i := 0; i < pubs; i++ {
-		s = b.PubStats.Clients[i]
-		buf[i] = results{Desc: fmt.Sprintf("P%d", i+1), MsgCnt: s.JobCount, MsgBytes: s.MsgBytes, MsgsPerSec: s.rate(), BytesPerSec: s.throughput(), DurationSecs: s.duration().Seconds()}
-	}
-	for i := 0; i < subs; i++ {
-		s = b.SubStats.Clients[i]
-		buf[pubs+i] = results{Desc: fmt.Sprintf("S%d", i+1), MsgCnt: s.JobCount, MsgBytes: s.MsgBytes, MsgsPerSec: s.rate(), BytesPerSec: s.throughput(), DurationSecs: s.duration().Seconds()}
-	}
-	return buf
-}
-
-func (b *benchStats) csv() string {
-	var buffer bytes.Buffer
-	writer := csv.NewWriter(&buffer)
-	writer.Write([]string{"ClientID", "MsgCount", "MsgBytes", "MsgsPerSec", "BytesPerSec", "DurationSecs"})
-	for _, i := range b.results() {
-		r := []string{i.Desc, fmt.Sprintf("%d", i.MsgCnt), fmt.Sprintf("%d", i.MsgBytes), fmt.Sprintf("%d", i.MsgsPerSec), fmt.Sprintf("%f", i.BytesPerSec), fmt.Sprintf("%f", i.DurationSecs)}
-		err := writer.Write(r)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-	writer.Flush()
-	return buffer.String()
-}
-
-func commaFormat(n int64) string {
-	in := strconv.FormatInt(n, 10)
-	out := make([]byte, len(in)+(len(in)-2+int(in[0]/'0'))/3)
-	if in[0] == '-' {
-		in, out[0] = in[1:], '-'
-	}
-	for i, j, k := len(in)-1, len(out)-1, 0; ; i, j = i-1, j-1 {
-		out[j] = in[i]
-		if i == 0 {
-			return string(out)
-		}
-		if k++; k == 3 {
-			j, k = j-1, 0
-			out[j] = ','
-		}
-	}
-}
-
-func humanBytes(bytes float64, si bool) string {
-	var base = 1024
-	pre := [...]string{"K", "M", "G", "T", "P", "E"}
-	var post = "B"
-	if si {
-		base = 1000
-		pre = [...]string{"k", "M", "G", "T", "P", "E"}
-		post = "iB"
-	}
-	if bytes < float64(base) {
-		return fmt.Sprintf("%.2f B", bytes)
-	}
-	exp := int(math.Log(bytes) / math.Log(float64(base)))
-	index := exp - 1
-	units := pre[index] + post
-	return fmt.Sprintf("%.2f %s", bytes/math.Pow(float64(base), float64(exp)), units)
-}
-
-func min(x, y int64) int64 {
-	if x < y {
-		return x
-	}
-	return y
-}
-
-func max(x, y int64) int64 {
-	if x > y {
-		return x
-	}
-	return y
-}
-
-func msgsPerClient(numMsgs, numClients int) []int {
-	var counts []int
-	if numClients == 0 || numMsgs == 0 {
-		return counts
-	}
-	counts = make([]int, numClients)
-	mc := numMsgs / numClients
-	for i := 0; i < numClients; i++ {
-		counts[i] = mc
-	}
-	extra := numMsgs % numClients
-	for i := 0; i < extra; i++ {
-		counts[i]++
-	}
-	return counts
 }


### PR DESCRIPTION
- Refactored `nats-bench` 'bench' functionality into a small library. Changed nats-bench to use bench package
- Added 'bench' package to github.com/nats-io/nats/bench 
- Added support for saving samples in CSV format with the intention of incorporating running of bench as part of the build and save historic performance information
- Added tests to bench package

@kozlovic @ColinSullivan1 
