### PR TITLE
Changes to nats-bench and bench lib

### DIFF
--- a/bench/bench.go
+++ b/bench/bench.go
@@ -266,7 +266,7 @@ func (bm *Benchmark) Report() string {
 		buffer.WriteString(fmt.Sprintf("%s%sPub stats: %s\n", indent, maybeTitle, bm.Pubs))
 		if len(bm.Pubs.Samples) > 1 {
 			for i, stat := range bm.Pubs.Samples {
-				buffer.WriteString(fmt.Sprintf("%s [%d] %v\n", indent, i+1, stat))
+				buffer.WriteString(fmt.Sprintf("%s [%d] %v (%d msgs)\n", indent, i+1, stat, stat.JobMsgCnt))
 			}
 			buffer.WriteString(fmt.Sprintf("%s %s\n", indent, bm.Pubs.Statistics()))
 		}
@@ -280,7 +280,7 @@ func (bm *Benchmark) Report() string {
 		buffer.WriteString(fmt.Sprintf("%s%sSub stats: %s\n", indent, maybeTitle, bm.Subs))
 		if len(bm.Subs.Samples) > 1 {
 			for i, stat := range bm.Subs.Samples {
-				buffer.WriteString(fmt.Sprintf("%s [%d] %v\n", indent, i+1, stat))
+				buffer.WriteString(fmt.Sprintf("%s [%d] %v (%d msgs)\n", indent, i+1, stat, stat.JobMsgCnt))
 			}
 			buffer.WriteString(fmt.Sprintf("%s %s\n", indent, bm.Subs.Statistics()))
 		}

--- a/examples/nats-bench.go
+++ b/examples/nats-bench.go
@@ -64,9 +64,8 @@ func main() {
 
 	// Run Subscribers first
 	startwg.Add(*numSubs)
-	subCounts := bench.MsgsPerClient(*numMsgs, *numSubs)
 	for i := 0; i < *numSubs; i++ {
-		go runSubscriber(&startwg, &donewg, opts, subCounts[i], *msgSize)
+		go runSubscriber(&startwg, &donewg, opts, *numMsgs, *msgSize)
 	}
 	startwg.Wait()
 


### PR DESCRIPTION
Modified nats-bench so that subscribers wait to receive the total message count.

Modified the bench library so that it adds the number of messages that the client received or published.