### PR TITLE
[ADDED] Support for processing of asynchronous INFO protocols

### DIFF
--- a/nats_test.go
+++ b/nats_test.go
@@ -14,8 +14,10 @@ import (
 	"testing"
 	"time"
 
+	"encoding/json"
 	"github.com/nats-io/gnatsd/server"
 	gnatsd "github.com/nats-io/gnatsd/test"
+	"runtime"
 )
 
 // Dumb wait program to sync on callbacks, etc... Will timeout
@@ -30,6 +32,23 @@ func WaitTime(ch chan bool, timeout time.Duration) error {
 	case <-time.After(timeout):
 	}
 	return errors.New("timeout")
+}
+
+func stackFatalf(t *testing.T, f string, args ...interface{}) {
+	lines := make([]string, 0, 32)
+	msg := fmt.Sprintf(f, args...)
+	lines = append(lines, msg)
+
+	// Generate the Stack of callers: Skip us and verify* frames.
+	for i := 2; true; i++ {
+		_, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		msg := fmt.Sprintf("%d - %s:%d", i, file, line)
+		lines = append(lines, msg)
+	}
+	t.Fatalf("%s", strings.Join(lines, "\n"))
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -834,8 +853,40 @@ func TestAsyncINFO(t *testing.T) {
 	// Server pool needs to be setup
 	c.setupServerPool()
 
+	// Partials requiring argBuf
+	expectedServer := serverInfo{
+		Id:           "test",
+		Host:         "localhost",
+		Port:         4222,
+		Version:      "1.2.3",
+		AuthRequired: true,
+		TLSRequired:  true,
+		MaxPayload:   2 * 1024 * 1024,
+		ConnectURLs:  []string{"localhost:5222", "localhost:6222"},
+	}
+	b, _ := json.Marshal(expectedServer)
+	info = []byte(fmt.Sprintf("INFO %s\r\n", b))
+	if c.ps.state != OP_START {
+		t.Fatalf("Expected OP_START vs %d\n", c.ps.state)
+	}
+	err = c.parse(info[:9])
+	if err != nil || c.ps.state != INFO_ARG || c.ps.argBuf == nil {
+		t.Fatalf("Unexpected: %d err: %v argBuf: %v\n", c.ps.state, err, c.ps.argBuf)
+	}
+	err = c.parse(info[9:11])
+	if err != nil || c.ps.state != INFO_ARG || c.ps.argBuf == nil {
+		t.Fatalf("Unexpected: %d err: %v argBuf: %v\n", c.ps.state, err, c.ps.argBuf)
+	}
+	err = c.parse(info[11:])
+	if err != nil || c.ps.state != OP_START || c.ps.argBuf != nil {
+		t.Fatalf("Unexpected: %d err: %v argBuf: %v\n", c.ps.state, err, c.ps.argBuf)
+	}
+	if !reflect.DeepEqual(c.info, expectedServer) {
+		t.Fatalf("Expected server info to be: %v, got: %v", expectedServer, c.info)
+	}
+
 	// Good INFOs
-	good := []string{"INFO {}\r\n", "INFO {} \r\n", "INFO { \"server_id\": \"test\"  }   \r\n", "INFO {\"connect_urls\":[]}\r\n"}
+	good := []string{"INFO {}\r\n", "INFO  {}\r\n", "INFO {} \r\n", "INFO { \"server_id\": \"test\"  }   \r\n", "INFO {\"connect_urls\":[]}\r\n"}
 	for _, gi := range good {
 		c.ps = &parseState{}
 		err = c.parse([]byte(gi))
@@ -845,7 +896,7 @@ func TestAsyncINFO(t *testing.T) {
 	}
 
 	// Wrong INFOs
-	wrong := []string{"INFOx {}\r\n", "INFO{}\r\n", "INFO {}"}
+	wrong := []string{"IxNFO {}\r\n", "INxFO {}\r\n", "INFxO {}\r\n", "INFOx {}\r\n", "INFO{}\r\n", "INFO {}"}
 	for _, wi := range wrong {
 		c.ps = &parseState{}
 		err = c.parse([]byte(wi))
@@ -857,19 +908,19 @@ func TestAsyncINFO(t *testing.T) {
 	checkPool := func(urls ...string) {
 		// Check both pool and urls map
 		if len(c.srvPool) != len(urls) {
-			t.Fatalf("Pool should have %d elements, has %d", len(urls), len(c.srvPool))
+			stackFatalf(t, "Pool should have %d elements, has %d", len(urls), len(c.srvPool))
 		}
 		if len(c.urls) != len(urls) {
-			t.Fatalf("Map should have %d elements, has %d", len(urls), len(c.urls))
+			stackFatalf(t, "Map should have %d elements, has %d", len(urls), len(c.urls))
 		}
 		for i, url := range urls {
 			if c.Opts.NoRandomize {
 				if c.srvPool[i].url.Host != url {
-					t.Fatalf("Pool should have %q at index %q, has %q", url, i, c.srvPool[i].url.Host)
+					stackFatalf(t, "Pool should have %q at index %q, has %q", url, i, c.srvPool[i].url.Host)
 				}
 			} else {
 				if _, present := c.urls[url]; !present {
-					t.Fatalf("Pool should have %q", url)
+					stackFatalf(t, "Pool should have %q", url)
 				}
 			}
 		}
@@ -881,6 +932,8 @@ func TestAsyncINFO(t *testing.T) {
 	c.Opts.NoRandomize = true
 	// Reset the pool
 	c.setupServerPool()
+	// Reinitialize the parser
+	c.ps = &parseState{}
 
 	info = []byte("INFO {\"connect_urls\":[\"localhost:5222\"]}\r\n")
 	err = c.parse(info)

--- a/parser.go
+++ b/parser.go
@@ -50,6 +50,12 @@ const (
 	OP_PO
 	OP_PON
 	OP_PONG
+	OP_I
+	OP_IN
+	OP_INF
+	OP_INFO
+	OP_INFO_SPC
+	OP_INFO_ARG
 )
 
 // parse is the fast protocol parser engine.
@@ -72,6 +78,8 @@ func (nc *Conn) parse(buf []byte) error {
 				nc.ps.state = OP_PLUS
 			case '-':
 				nc.ps.state = OP_MINUS
+			case 'I', 'i':
+				nc.ps.state = OP_I
 			default:
 				goto parseErr
 			}
@@ -288,6 +296,61 @@ func (nc *Conn) parse(buf []byte) error {
 			case '\n':
 				nc.processPing()
 				nc.ps.drop, nc.ps.state = 0, OP_START
+			}
+		case OP_I:
+			switch b {
+			case 'N', 'n':
+				nc.ps.state = OP_IN
+			default:
+				goto parseErr
+			}
+		case OP_IN:
+			switch b {
+			case 'F', 'f':
+				nc.ps.state = OP_INF
+			default:
+				goto parseErr
+			}
+		case OP_INF:
+			switch b {
+			case 'O', 'o':
+				nc.ps.state = OP_INFO
+			default:
+				goto parseErr
+			}
+		case OP_INFO:
+			switch b {
+			case ' ', '\t':
+				nc.ps.state = OP_INFO_SPC
+			default:
+				goto parseErr
+			}
+		case OP_INFO_SPC:
+			switch b {
+			case ' ', '\t':
+				continue
+			default:
+				nc.ps.state = OP_INFO_ARG
+				nc.ps.as = i
+			}
+		case OP_INFO_ARG:
+			switch b {
+			case '\r':
+				nc.ps.drop = 1
+			case '\n':
+				var arg []byte
+				if nc.ps.argBuf != nil {
+					arg = nc.ps.argBuf
+					nc.ps.argBuf = nil
+				} else {
+					arg = buf[nc.ps.as : i-nc.ps.drop]
+				}
+				nc.processAsyncInfo(arg)
+				nc.ps.drop, nc.ps.as, nc.ps.state = 0, i+1, OP_START
+			default:
+				if nc.ps.argBuf != nil {
+					nc.ps.argBuf = append(nc.ps.argBuf, b)
+				}
 			}
 		default:
 			goto parseErr

--- a/parser.go
+++ b/parser.go
@@ -55,7 +55,7 @@ const (
 	OP_INF
 	OP_INFO
 	OP_INFO_SPC
-	OP_INFO_ARG
+	INFO_ARG
 )
 
 // parse is the fast protocol parser engine.
@@ -330,10 +330,10 @@ func (nc *Conn) parse(buf []byte) error {
 			case ' ', '\t':
 				continue
 			default:
-				nc.ps.state = OP_INFO_ARG
+				nc.ps.state = INFO_ARG
 				nc.ps.as = i
 			}
-		case OP_INFO_ARG:
+		case INFO_ARG:
 			switch b {
 			case '\r':
 				nc.ps.drop = 1
@@ -357,7 +357,7 @@ func (nc *Conn) parse(buf []byte) error {
 		}
 	}
 	// Check for split buffer scenarios
-	if (nc.ps.state == MSG_ARG || nc.ps.state == MINUS_ERR_ARG) && nc.ps.argBuf == nil {
+	if (nc.ps.state == MSG_ARG || nc.ps.state == MINUS_ERR_ARG || nc.ps.state == INFO_ARG) && nc.ps.argBuf == nil {
 		nc.ps.argBuf = nc.ps.scratch[:0]
 		nc.ps.argBuf = append(nc.ps.argBuf, buf[nc.ps.as:i-nc.ps.drop]...)
 		// FIXME, check max len

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -38,6 +38,19 @@ func TestAuth(t *testing.T) {
 		t.Fatal("Should have connected successfully with a token")
 	}
 	nc.Close()
+
+	// Use Options
+	nc, err = nats.Connect("nats://localhost:8232", nats.UserInfo("derek", "foo"))
+	if err != nil {
+		t.Fatalf("Should have connected successfully with a token: %v", err)
+	}
+	nc.Close()
+	// Verify that credentials in URL take precedence.
+	nc, err = nats.Connect("nats://derek:foo@localhost:8232", nats.UserInfo("foo", "bar"))
+	if err != nil {
+		t.Fatalf("Should have connected successfully with a token: %v", err)
+	}
+	nc.Close()
 }
 
 func TestAuthFailNoDisconnectCB(t *testing.T) {
@@ -145,10 +158,23 @@ func TestTokenAuth(t *testing.T) {
 		t.Fatal("Should have received an error while trying to connect")
 	}
 
-	tokenUrl := fmt.Sprintf("nats://%s@localhost:8232", secret)
-	nc, err := nats.Connect(tokenUrl)
+	tokenURL := fmt.Sprintf("nats://%s@localhost:8232", secret)
+	nc, err := nats.Connect(tokenURL)
 	if err != nil {
 		t.Fatal("Should have connected successfully")
+	}
+	nc.Close()
+
+	// Use Options
+	nc, err = nats.Connect("nats://localhost:8232", nats.Token(secret))
+	if err != nil {
+		t.Fatalf("Should have connected successfully: %v", err)
+	}
+	nc.Close()
+	// Verify that token in the URL takes precedence.
+	nc, err = nats.Connect(tokenURL, nats.Token("badtoken"))
+	if err != nil {
+		t.Fatalf("Should have connected successfully: %v", err)
 	}
 	nc.Close()
 }


### PR DESCRIPTION
This would be used in conjunction with server's PR #314.
The client may receive INFO protocols with a field containing
a possible array of URLs that correspond to server addresses in
the full mesh cluster that clients can connect to.
The server pool is updated with these URLs.
3 new Options and 2 new Options setters have been introduced to
manage username/password and/or tokens when dealing with these
bare URLs.

/cc @derekcollison 