### PR TITLE
Add `ConnectedHost` to check current connected server

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -837,7 +837,7 @@ func (nc *Conn) ConnectedHost() string {
 	if nc.status != CONNECTED {
 		return _EMPTY_
 	}
-	return fmt.Sprintf("nats://%s", nc.url.Host)
+	return fmt.Sprintf("%s://%s", nc.url.Scheme, nc.url.Host)
 }
 
 // ConnectedServerId reports the connected server's Id

--- a/nats.go
+++ b/nats.go
@@ -814,7 +814,7 @@ func (nc *Conn) spinUpGoRoutines() {
 	nc.mu.Unlock()
 }
 
-// Report the connected server's Url
+// ConnectedUrl reports the connected server's Url
 func (nc *Conn) ConnectedUrl() string {
 	if nc == nil {
 		return _EMPTY_
@@ -827,7 +827,20 @@ func (nc *Conn) ConnectedUrl() string {
 	return nc.url.String()
 }
 
-// Report the connected server's Id
+// ConnectedHost reports the connected server's Host
+func (nc *Conn) ConnectedHost() string {
+	if nc == nil {
+		return _EMPTY_
+	}
+	nc.mu.Lock()
+	defer nc.mu.Unlock()
+	if nc.status != CONNECTED {
+		return _EMPTY_
+	}
+	return nc.url.Host
+}
+
+// ConnectedServerId reports the connected server's Id
 func (nc *Conn) ConnectedServerId() string {
 	if nc == nil {
 		return _EMPTY_

--- a/nats.go
+++ b/nats.go
@@ -837,7 +837,7 @@ func (nc *Conn) ConnectedHost() string {
 	if nc.status != CONNECTED {
 		return _EMPTY_
 	}
-	return nc.url.Host
+	return fmt.Sprintf("nats://%s", nc.url.Host)
 }
 
 // ConnectedServerId reports the connected server's Id

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -61,7 +61,7 @@ func TestAuth(t *testing.T) {
 
 	// Confirm we can get the connected host without credentials as well
 	got = nc.ConnectedHost()
-	expected = "localhost:8232"
+	expected = "nats://localhost:8232"
 	if got != expected {
 		t.Errorf("Expected url as %s got: %s", expected, got)
 	}

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -45,11 +45,27 @@ func TestAuth(t *testing.T) {
 		t.Fatalf("Should have connected successfully with a token: %v", err)
 	}
 	nc.Close()
+
 	// Verify that credentials in URL take precedence.
 	nc, err = nats.Connect("nats://derek:foo@localhost:8232", nats.UserInfo("foo", "bar"))
 	if err != nil {
 		t.Fatalf("Should have connected successfully with a token: %v", err)
 	}
+
+	// Confirm credentials are part of the url
+	got := nc.ConnectedUrl()
+	expected := "nats://derek:foo@localhost:8232"
+	if got != expected {
+		t.Errorf("Expected url as %s got: %s", expected, got)
+	}
+
+	// Confirm we can get the connected host without credentials as well
+	got = nc.ConnectedHost()
+	expected = "localhost:8232"
+	if got != expected {
+		t.Errorf("Expected url as %s got: %s", expected, got)
+	}
+
 	nc.Close()
 }
 


### PR DESCRIPTION
This can be helpful when only wanting to check against which server endpoint we are connected/reconnected as `ConnectedUrl` could include the credentials in the url string.